### PR TITLE
Fix definitions.yml->wireless-encryption $ref,  to match other schema yml $ref paths

### DIFF
--- a/schema/definitions.yml
+++ b/schema/definitions.yml
@@ -11,5 +11,5 @@ properties:
       by the corresponding property name.
     patternProperties:
       ".+":
-        $ref: "#/$defs/interface.ssid.encryption"
+        $ref: "https://ucentral.io/schema/v1/interface/ssid/encryption/"
         additionalProperties: false

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -369,6 +369,84 @@ function instantiateGlobals(location, value, errors) {
 	return value;
 }
 
+function instantiateInterfaceSsidEncryption(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseProto(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			if (!(value in [ "none", "owe", "owe-transition", "psk", "psk2", "psk-mixed", "psk2-radius", "wpa", "wpa2", "wpa-mixed", "sae", "sae-mixed", "wpa3", "wpa3-192", "wpa3-mixed" ]))
+				push(errors, [ location, "must be one of \"none\", \"owe\", \"owe-transition\", \"psk\", \"psk2\", \"psk-mixed\", \"psk2-radius\", \"wpa\", \"wpa2\", \"wpa-mixed\", \"sae\", \"sae-mixed\", \"wpa3\", \"wpa3-192\" or \"wpa3-mixed\"" ]);
+
+			return value;
+		}
+
+		if (exists(value, "proto")) {
+			obj.proto = parseProto(location + "/proto", value["proto"], errors);
+		}
+
+		function parseKey(location, value, errors) {
+			if (type(value) == "string") {
+				if (length(value) > 63)
+					push(errors, [ location, "must be at most 63 characters long" ]);
+
+				if (length(value) < 8)
+					push(errors, [ location, "must be at least 8 characters long" ]);
+
+			}
+
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "key")) {
+			obj.key = parseKey(location + "/key", value["key"], errors);
+		}
+
+		function parseIeee80211w(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			if (!(value in [ "disabled", "optional", "required" ]))
+				push(errors, [ location, "must be one of \"disabled\", \"optional\" or \"required\"" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ieee80211w")) {
+			obj.ieee80211w = parseIeee80211w(location + "/ieee80211w", value["ieee80211w"], errors);
+		}
+		else {
+			obj.ieee80211w = "disabled";
+		}
+
+		function parseKeyCaching(location, value, errors) {
+			if (type(value) != "bool")
+				push(errors, [ location, "must be of type boolean" ]);
+
+			return value;
+		}
+
+		if (exists(value, "key-caching")) {
+			obj.key_caching = parseKeyCaching(location + "/key-caching", value["key-caching"], errors);
+		}
+		else {
+			obj.key_caching = true;
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
 function instantiateDefinitions(location, value, errors) {
 	if (type(value) == "object") {
 		let obj = {};
@@ -2331,84 +2409,6 @@ function instantiateInterfaceBroadBand(location, value, errors) {
 	}
 
 	value = vvalue;
-
-	return value;
-}
-
-function instantiateInterfaceSsidEncryption(location, value, errors) {
-	if (type(value) == "object") {
-		let obj = {};
-
-		function parseProto(location, value, errors) {
-			if (type(value) != "string")
-				push(errors, [ location, "must be of type string" ]);
-
-			if (!(value in [ "none", "owe", "owe-transition", "psk", "psk2", "psk-mixed", "psk2-radius", "wpa", "wpa2", "wpa-mixed", "sae", "sae-mixed", "wpa3", "wpa3-192", "wpa3-mixed" ]))
-				push(errors, [ location, "must be one of \"none\", \"owe\", \"owe-transition\", \"psk\", \"psk2\", \"psk-mixed\", \"psk2-radius\", \"wpa\", \"wpa2\", \"wpa-mixed\", \"sae\", \"sae-mixed\", \"wpa3\", \"wpa3-192\" or \"wpa3-mixed\"" ]);
-
-			return value;
-		}
-
-		if (exists(value, "proto")) {
-			obj.proto = parseProto(location + "/proto", value["proto"], errors);
-		}
-
-		function parseKey(location, value, errors) {
-			if (type(value) == "string") {
-				if (length(value) > 63)
-					push(errors, [ location, "must be at most 63 characters long" ]);
-
-				if (length(value) < 8)
-					push(errors, [ location, "must be at least 8 characters long" ]);
-
-			}
-
-			if (type(value) != "string")
-				push(errors, [ location, "must be of type string" ]);
-
-			return value;
-		}
-
-		if (exists(value, "key")) {
-			obj.key = parseKey(location + "/key", value["key"], errors);
-		}
-
-		function parseIeee80211w(location, value, errors) {
-			if (type(value) != "string")
-				push(errors, [ location, "must be of type string" ]);
-
-			if (!(value in [ "disabled", "optional", "required" ]))
-				push(errors, [ location, "must be one of \"disabled\", \"optional\" or \"required\"" ]);
-
-			return value;
-		}
-
-		if (exists(value, "ieee80211w")) {
-			obj.ieee80211w = parseIeee80211w(location + "/ieee80211w", value["ieee80211w"], errors);
-		}
-		else {
-			obj.ieee80211w = "disabled";
-		}
-
-		function parseKeyCaching(location, value, errors) {
-			if (type(value) != "bool")
-				push(errors, [ location, "must be of type boolean" ]);
-
-			return value;
-		}
-
-		if (exists(value, "key-caching")) {
-			obj.key_caching = parseKeyCaching(location + "/key-caching", value["key-caching"], errors);
-		}
-		else {
-			obj.key_caching = true;
-		}
-
-		return obj;
-	}
-
-	if (type(value) != "object")
-		push(errors, [ location, "must be of type object" ]);
 
 	return value;
 }

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -191,6 +191,52 @@
                 }
             }
         },
+        "interface.ssid.encryption": {
+            "type": "object",
+            "properties": {
+                "proto": {
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "owe",
+                        "owe-transition",
+                        "psk",
+                        "psk2",
+                        "psk-mixed",
+                        "psk2-radius",
+                        "wpa",
+                        "wpa2",
+                        "wpa-mixed",
+                        "sae",
+                        "sae-mixed",
+                        "wpa3",
+                        "wpa3-192",
+                        "wpa3-mixed"
+                    ],
+                    "examples": [
+                        "psk2"
+                    ]
+                },
+                "key": {
+                    "type": "string",
+                    "maxLength": 63,
+                    "minLength": 8
+                },
+                "ieee80211w": {
+                    "type": "string",
+                    "enum": [
+                        "disabled",
+                        "optional",
+                        "required"
+                    ],
+                    "default": "disabled"
+                },
+                "key-caching": {
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
         "definitions": {
             "type": "object",
             "properties": {
@@ -974,52 +1020,6 @@
                     "$ref": "#/$defs/interface.broad-band.pppoe"
                 }
             ]
-        },
-        "interface.ssid.encryption": {
-            "type": "object",
-            "properties": {
-                "proto": {
-                    "type": "string",
-                    "enum": [
-                        "none",
-                        "owe",
-                        "owe-transition",
-                        "psk",
-                        "psk2",
-                        "psk-mixed",
-                        "psk2-radius",
-                        "wpa",
-                        "wpa2",
-                        "wpa-mixed",
-                        "sae",
-                        "sae-mixed",
-                        "wpa3",
-                        "wpa3-192",
-                        "wpa3-mixed"
-                    ],
-                    "examples": [
-                        "psk2"
-                    ]
-                },
-                "key": {
-                    "type": "string",
-                    "maxLength": 63,
-                    "minLength": 8
-                },
-                "ieee80211w": {
-                    "type": "string",
-                    "enum": [
-                        "disabled",
-                        "optional",
-                        "required"
-                    ],
-                    "default": "disabled"
-                },
-                "key-caching": {
-                    "type": "boolean",
-                    "default": true
-                }
-            }
         },
         "interface.ssid.multi-psk": {
             "type": "object",


### PR DESCRIPTION
The $ref in definitions.yml for the wireless-encryption property is not correctly parsed by merge-schema.py, when generating ucentral.schema.pretty.json and ucentral.schema.full.json, as it deviates from the pattern used for the other schema references.
Changed to follow the same pattern as the rest of the constituent elements.
Included updated schemareader.uc file that is generated by the script as well.