### PR TITLE
dhcp-relay: dhcp relay option 82 parameters

### DIFF
--- a/renderer/templates/services/dhcp_relay.uc
+++ b/renderer/templates/services/dhcp_relay.uc
@@ -31,4 +31,6 @@ add_list dhcprelay.relay.upstream={{ port }}
 {% for (let vlan in dhcp_relay.vlans||[]): %}
 set dhcprelay.vlan{{vlan.vlan}}=config
 set dhcprelay.vlan{{vlan.vlan}}.server={{ s(vlan.relay_server) }}
+set dhcprelay.vlan{{vlan.vlan}}.circuit_id={{ s(vlan?.circuit_id_format) }}
+set dhcprelay.vlan{{vlan.vlan}}.remote_id={{ s(vlan?.remote_id_format) }}
 {% endfor %}

--- a/schema/service.dhcp-relay.yml
+++ b/schema/service.dhcp-relay.yml
@@ -25,3 +25,23 @@ properties:
             The unicast target DHCP pool server where frames get relayed to.
           type: string
           format: uc-ip
+        circuit-id-format:
+          description:
+            This option selects what info shall be contained within a relayed
+            frame's circuit ID.
+          type: string
+          enum:
+          - vlan-id
+          - ap-mac
+          - ssid
+          default: vlan-id
+        remote-id-format:
+          description:
+            This option selects what info shall be contained within a relayed
+            frame's remote ID.
+          type: string
+          enum:
+          - vlan-id
+          - ap-mac
+          - ssid
+          default: ap-mac

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -8713,6 +8713,40 @@ function instantiateServiceDhcpRelay(location, value, errors) {
 							obj.relay_server = parseRelayServer(location + "/relay-server", value["relay-server"], errors);
 						}
 
+						function parseCircuitIdFormat(location, value, errors) {
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							if (!(value in [ "vlan-id", "ap-mac", "ssid" ]))
+								push(errors, [ location, "must be one of \"vlan-id\", \"ap-mac\" or \"ssid\"" ]);
+
+							return value;
+						}
+
+						if (exists(value, "circuit-id-format")) {
+							obj.circuit_id_format = parseCircuitIdFormat(location + "/circuit-id-format", value["circuit-id-format"], errors);
+						}
+						else {
+							obj.circuit_id_format = "vlan-id";
+						}
+
+						function parseRemoteIdFormat(location, value, errors) {
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							if (!(value in [ "vlan-id", "ap-mac", "ssid" ]))
+								push(errors, [ location, "must be one of \"vlan-id\", \"ap-mac\" or \"ssid\"" ]);
+
+							return value;
+						}
+
+						if (exists(value, "remote-id-format")) {
+							obj.remote_id_format = parseRemoteIdFormat(location + "/remote-id-format", value["remote-id-format"], errors);
+						}
+						else {
+							obj.remote_id_format = "ap-mac";
+						}
+
 						return obj;
 					}
 

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3107,6 +3107,24 @@
                             "relay-server": {
                                 "type": "string",
                                 "format": "uc-ip"
+                            },
+                            "circuit-id-format": {
+                                "type": "string",
+                                "enum": [
+                                    "vlan-id",
+                                    "ap-mac",
+                                    "ssid"
+                                ],
+                                "default": "vlan-id"
+                            },
+                            "remote-id-format": {
+                                "type": "string",
+                                "enum": [
+                                    "vlan-id",
+                                    "ap-mac",
+                                    "ssid"
+                                ],
+                                "default": "ap-mac"
                             }
                         }
                     }


### PR DESCRIPTION
Add the ability to configure circuit-id and remote-id sub-options.