### PR TITLE
Fix state/interface.ssid.yml

### DIFF
--- a/state/interface.ssid.yml
+++ b/state/interface.ssid.yml
@@ -32,11 +32,13 @@ items:
     vlan_ifaces:
       description:
         The list of dynamic vlan interfaces.
-      type: object
-      patternProperties:
-        ^wlan-v:
-          type: object
-          $ref: "https://ucentral.io/state/v1/interface/counter/"
+      type: array
+      items:
+        type: object
+        patternProperties:
+          ^wlan-v:
+            type: object
+            $ref: "https://ucentral.io/state/v1/interface/counter/"
     mode:
       type: string
       description:


### PR DESCRIPTION
The state message cannot deserialize properly against the defined ucentral.state.pretty.json when vlan_ifaces are present in ssid, as there is conflict between array (actual) vs object (defined)
The definition for state/interface.ssid.yml had vlan_ifaces as an object containing 0..n entries.

The state.uc script is handling as an array of entries, which is actually more logical/correct.
                                if (dyn_vlans[vap.ifname]) {
                                        **ssid.vlan_ifaces = [];**
                                        for (let vlan in dyn_vlans[vap.ifname]) {
                                                let vid = +split(vlan, '-v')[1];
                                                push(dyn_vids, vid);
                                                push(ssid.vlan_ifaces, { ...(ports[vlan]?.counters || {}), ...{ vid} });
                                        }
                                }


Changed the schema definition and regenerated.
Message generates on AP successfully and can be parsed against the new ucentral state schema definition 
