### PR TITLE
bridge-vlan: add wan port only behind swconfig

### DIFF
--- a/renderer/templates/interface/bridge-vlan.uc
+++ b/renderer/templates/interface/bridge-vlan.uc
@@ -66,11 +66,12 @@ set network.@switch_vlan[-1].ports={{s(swconfig.ports)}}
 {% endif %}
 
 {% if (interface.role == 'upstream' && swconfig && !interface.vlan.id): %}
-{%   for (let dev in keys(eth_ports)):
-        if (ethernet.swconfig && ethernet.swconfig[dev]): %}
+{%   if ("WAN" in ethernet.ports):
+       dev = ethernet.ports["WAN"].netdev;
+       if (ethernet.swconfig && ethernet.swconfig[dev]): %}
 set event.config.swconfig={{ethernet.swconfig[dev].switch?.name}}
 add_list event.config.swconfig_ports={{ethernet.swconfig[dev].swconfig}}t
 add_list event.config.swconfig_ports={{ethernet.swconfig[dev].switch?.port}}t
 {%     endif %}
-{%   endfor %}
+{%   endif %}
 {% endif %}


### PR DESCRIPTION
Configure only the switch port for the WAN port instead of all Ethernet ports.  When adding a dynamic VLAN, it should be added to the WAN port as tagged only, and not the LAN ports.

When LAN ports were included in the interface config, it resulted in their switch ports also being added to event.swconfig.ports as well as
duplicating the CPU port for each LAN port.   This also caused the
swconfig command to fail.

Config before the fix:
    config config 'config'
        list wan_port 'eth0.1'
        option swconfig 'switch1'
        list swconfig_ports '5t'
        list swconfig_ports '6t'
        list swconfig_ports '2t'
        list swconfig_ports '6t'
        list swconfig_ports '3t'
        list swconfig_ports '6t'
        list swconfig_ports '4t'
        list swconfig_ports '6t'

Config after the fix:
    config config 'config'
        list wan_port 'eth0.1'
        option swconfig 'switch1'
        list swconfig_ports '5t'
        list swconfig_ports '6t'