### PR TITLE
Fixes WIFI-13641 strict forwarding for yuncore_fap655

### DIFF
--- a/command/cmd_factory.uc
+++ b/command/cmd_factory.uc
@@ -42,5 +42,5 @@ if (length(args) && args.keep_redirector) {
 include('reboot_cause.uc', { reason: 'factory' });
 
 system("touch /ucentral.upgrade");
-system("(sleep 10; /etc/init.d/network stop; " + reset_cmdline + ")&");
+system("(sleep 10; " + join(' ', reset_cmdline) + ")&");
 system("/etc/init.d/ucentral stop");

--- a/renderer/templates/interface/bridge-vlan.uc
+++ b/renderer/templates/interface/bridge-vlan.uc
@@ -80,6 +80,8 @@ set network.@switch_vlan[-1].ports={{s(port.switch.port + 't ' + port.swconfig)}
 {%   if ("WAN" in ethernet.ports):
        dev = ethernet.ports["WAN"].netdev;
        if (ethernet.swconfig && ethernet.swconfig[dev]): %}
+del event.config.wan_port
+add_list event.config.wan_port={{dev}}
 set event.config.swconfig={{ethernet.swconfig[dev].switch?.name}}
 add_list event.config.swconfig_ports={{ethernet.swconfig[dev].swconfig}}t
 add_list event.config.swconfig_ports={{ethernet.swconfig[dev].switch?.port}}t

--- a/renderer/templates/radio.uc
+++ b/renderer/templates/radio.uc
@@ -1,4 +1,5 @@
 {%
+	let fs = require('fs');
 	let phys = wiphy.lookup_by_band(radio.band);
 
 	if (!length(phys)) {
@@ -162,6 +163,29 @@
 		warn('DFS is restricted.');
 		radio.allow_dfs = false;
 	}
+
+	let afc = false;
+	let afc_location;
+	if (radio.band == '6G')
+		fs.unlink('/tmp/afc-location-missing');
+	if (radio.band == '6G' && radio.country == 'US' && radio.he_6ghz_settings?.power_type != 'very-low-power') {
+		afc = true;
+		if (!radio.he_6ghz_settings.controller ||
+		    !radio.he_6ghz_settings.serial_number ||
+		    !radio.he_6ghz_settings.certificates_ids ||
+		    !radio.he_6ghz_settings.frequency_ranges ||
+		    !radio.he_6ghz_settings.operation_classes)
+			die('invalid AFC settings');
+		afc_location = fs.readfile('/etc/ucentral/afc-location.json');
+		if (afc_location)
+			afc_location = json(afc_location);
+		if (!afc_location) {
+			fs.writefile('/tmp/afc-location-missing', 'true');
+			warn('AFC location is missing, skipping 6GHz radio');
+			return;
+		}
+	}
+
 %}
 
 # Wireless Configuration
@@ -202,5 +226,27 @@ add_list wireless.{{ phy.section }}.hostapd_options={{ s(raw) }}
 {%  endfor %}
 {%  if (radio.band == "6G"): %}
 set wireless.{{ phy.section }}.he_co_locate={{ b(1) }}
+{%  endif %}
+{%  if (afc): %}
+set wireless.{{ phy.section }}.afc=1
+set wireless.{{ phy.section }}.afc_request_version='1.4'=
+set wireless.{{ phy.section }}.afc_request_id={{ s(radio.he_6ghz_settings.request_id) }}
+set wireless.{{ phy.section }}.afc_serial_number={{ s(radio.he_6ghz_settingsafc_serial_number) }}
+set wireless.{{ phy.section }}.afc_cert_ids={{ s(radio.he_6ghz_settings.certificate_ids) }}
+set wireless.{{ phy.section }}.afc_min_power{{radio.he_6ghz_settings.minimum_power}}
+{%    if (radio.he_6ghz_settings.frequency_ranges): %}
+set wireless.{{ phy.section }}.afc_freq_range{{s(join(',', radio.he_6ghz_settings.frequency_ranges)) }}
+{%    endif %}
+{%    if (radio.he_6ghz_settings.operating_classes): %}
+set wireless.{{ phy.section }}.afc_freq_range{{s(join(',', radio.he_6ghz_settings.operating_classes)) }}
+{%    endif %}
+set wireless.{{ phy.section }}.afc_location_type={{ s(afc_location.location_type) }}
+set wireless.{{ phy.section }}.afc_location={{ s(afc_location.location) }}
+set wireless.{{ phy.section }}.afc_major_axis={{ s(afc_location.major_axis) }}
+set wireless.{{ phy.section }}.afc_minor_axis={{ s(afc_location.minor_axis) }}
+set wireless.{{ phy.section }}.afc_orientation={{ s(afc_location.orientation) }}
+set wireless.{{ phy.section }}.afc_height={{ s(afc_location.height) }}
+set wireless.{{ phy.section }}.afc_height_type={{ s(afc_location.height_type) }}
+set wireless.{{ phy.section }}.afc_vertical_tolerance={{ s(afc_location.vertical_tolerance) }}
 {%  endif %}
 {% endfor %}

--- a/schema/radio.he-6ghz.yml
+++ b/schema/radio.he-6ghz.yml
@@ -1,0 +1,44 @@
+type: object
+properties:
+  power-type:
+    description:
+     This config is to set the 6 GHz Access Point type
+    type: string
+    enum:
+    - indoor-power-indoor
+    - standard-power
+    - very-low-power
+    default: very-low-power
+  controller:
+    description:
+      The URL of the AFC controller that the AP shall connect to.
+    type: string
+  ca-certificate:
+    description:
+      The CA of the server. This enables mTLS.
+    type: string
+    format: uc-base64
+  serial-number:
+    description:
+      The serial number that the AP shall send to the AFC controller.
+    type: string
+  certificate-ids:
+    description:
+      The certificate IDs that the AP shall send to the AFC controller.
+    type: string
+  minimum-power:
+    description:
+      The minimum power that the AP shall request from to the AFC controller.
+    type: number
+  frequency-ranges:
+    description:
+      The list of frequency ranges that the AP shall request from to the AFC controller.
+    type: array
+    items:
+      type: string
+  operating-classes:
+    description:
+      The list of frequency ranges that the AP shall request from to the AFC controller.
+    type: array
+    items:
+      type: number

--- a/schema/radio.yml
+++ b/schema/radio.yml
@@ -136,6 +136,8 @@ properties:
     $ref: "https://ucentral.io/schema/v1/radio/rates/"
   he-settings:
     $ref: "https://ucentral.io/schema/v1/radio/he/"
+  he-6ghz-settings:
+    $ref: "https://ucentral.io/schema/v1/radio/he-6ghz/"
   hostapd-iface-raw:
     description:
       This array allows passing raw hostapd.conf lines.

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -843,6 +843,141 @@ function instantiateRadioHe(location, value, errors) {
 	return value;
 }
 
+function instantiateRadioHe6ghz(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parsePowerType(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			if (!(value in [ "indoor-power-indoor", "standard-power", "very-low-power" ]))
+				push(errors, [ location, "must be one of \"indoor-power-indoor\", \"standard-power\" or \"very-low-power\"" ]);
+
+			return value;
+		}
+
+		if (exists(value, "power-type")) {
+			obj.power_type = parsePowerType(location + "/power-type", value["power-type"], errors);
+		}
+		else {
+			obj.power_type = "very-low-power";
+		}
+
+		function parseController(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "controller")) {
+			obj.controller = parseController(location + "/controller", value["controller"], errors);
+		}
+
+		function parseCaCertificate(location, value, errors) {
+			if (type(value) == "string") {
+				if (!matchUcBase64(value))
+					push(errors, [ location, "must be a valid base64 encoded data" ]);
+
+			}
+
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ca-certificate")) {
+			obj.ca_certificate = parseCaCertificate(location + "/ca-certificate", value["ca-certificate"], errors);
+		}
+
+		function parseSerialNumber(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "serial-number")) {
+			obj.serial_number = parseSerialNumber(location + "/serial-number", value["serial-number"], errors);
+		}
+
+		function parseCertificateIds(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "certificate-ids")) {
+			obj.certificate_ids = parseCertificateIds(location + "/certificate-ids", value["certificate-ids"], errors);
+		}
+
+		function parseMinimumPower(location, value, errors) {
+			if (!(type(value) in [ "int", "double" ]))
+				push(errors, [ location, "must be of type number" ]);
+
+			return value;
+		}
+
+		if (exists(value, "minimum-power")) {
+			obj.minimum_power = parseMinimumPower(location + "/minimum-power", value["minimum-power"], errors);
+		}
+
+		function parseFrequencyRanges(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "frequency-ranges")) {
+			obj.frequency_ranges = parseFrequencyRanges(location + "/frequency-ranges", value["frequency-ranges"], errors);
+		}
+
+		function parseOperatingClasses(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (!(type(value) in [ "int", "double" ]))
+						push(errors, [ location, "must be of type number" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "operating-classes")) {
+			obj.operating_classes = parseOperatingClasses(location + "/operating-classes", value["operating-classes"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
 function instantiateRadio(location, value, errors) {
 	if (type(value) == "object") {
 		let obj = {};
@@ -1161,6 +1296,10 @@ function instantiateRadio(location, value, errors) {
 
 		if (exists(value, "he-settings")) {
 			obj.he_settings = instantiateRadioHe(location + "/he-settings", value["he-settings"], errors);
+		}
+
+		if (exists(value, "he-6ghz-settings")) {
+			obj.he_6ghz_settings = instantiateRadioHe6ghz(location + "/he-6ghz-settings", value["he-6ghz-settings"], errors);
 		}
 
 		function parseHostapdIfaceRaw(location, value, errors) {

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -743,6 +743,56 @@
                             }
                         }
                     },
+                    "he-6ghz-settings": {
+                        "type": "object",
+                        "properties": {
+                            "power-type": {
+                                "description": "This config is to set the 6 GHz Access Point type",
+                                "type": "string",
+                                "enum": [
+                                    "indoor-power-indoor",
+                                    "standard-power",
+                                    "very-low-power"
+                                ],
+                                "default": "very-low-power"
+                            },
+                            "controller": {
+                                "description": "The URL of the AFC controller that the AP shall connect to.",
+                                "type": "string"
+                            },
+                            "ca-certificate": {
+                                "description": "The CA of the server. This enables mTLS.",
+                                "type": "string",
+                                "format": "uc-base64"
+                            },
+                            "serial-number": {
+                                "description": "The serial number that the AP shall send to the AFC controller.",
+                                "type": "string"
+                            },
+                            "certificate-ids": {
+                                "description": "The certificate IDs that the AP shall send to the AFC controller.",
+                                "type": "string"
+                            },
+                            "minimum-power": {
+                                "description": "The minimum power that the AP shall request from to the AFC controller.",
+                                "type": "number"
+                            },
+                            "frequency-ranges": {
+                                "description": "The list of frequency ranges that the AP shall request from to the AFC controller.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "operating-classes": {
+                                "description": "The list of frequency ranges that the AP shall request from to the AFC controller.",
+                                "type": "array",
+                                "items": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    },
                     "hostapd-iface-raw": {
                         "description": "This array allows passing raw hostapd.conf lines.",
                         "type": "array",

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -412,6 +412,48 @@
                 }
             }
         },
+        "radio.he-6ghz": {
+            "type": "object",
+            "properties": {
+                "power-type": {
+                    "type": "string",
+                    "enum": [
+                        "indoor-power-indoor",
+                        "standard-power",
+                        "very-low-power"
+                    ],
+                    "default": "very-low-power"
+                },
+                "controller": {
+                    "type": "string"
+                },
+                "ca-certificate": {
+                    "type": "string",
+                    "format": "uc-base64"
+                },
+                "serial-number": {
+                    "type": "string"
+                },
+                "certificate-ids": {
+                    "type": "string"
+                },
+                "minimum-power": {
+                    "type": "number"
+                },
+                "frequency-ranges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operating-classes": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
         "radio": {
             "type": "object",
             "properties": {
@@ -536,6 +578,9 @@
                 },
                 "he-settings": {
                     "$ref": "#/$defs/radio.he"
+                },
+                "he-6ghz-settings": {
+                    "$ref": "#/$defs/radio.he-6ghz"
                 },
                 "hostapd-iface-raw": {
                     "type": "array",

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -457,6 +457,56 @@
                 }
             }
         },
+        "radio.he-6ghz": {
+            "type": "object",
+            "properties": {
+                "power-type": {
+                    "description": "This config is to set the 6 GHz Access Point type",
+                    "type": "string",
+                    "enum": [
+                        "indoor-power-indoor",
+                        "standard-power",
+                        "very-low-power"
+                    ],
+                    "default": "very-low-power"
+                },
+                "controller": {
+                    "description": "The URL of the AFC controller that the AP shall connect to.",
+                    "type": "string"
+                },
+                "ca-certificate": {
+                    "description": "The CA of the server. This enables mTLS.",
+                    "type": "string",
+                    "format": "uc-base64"
+                },
+                "serial-number": {
+                    "description": "The serial number that the AP shall send to the AFC controller.",
+                    "type": "string"
+                },
+                "certificate-ids": {
+                    "description": "The certificate IDs that the AP shall send to the AFC controller.",
+                    "type": "string"
+                },
+                "minimum-power": {
+                    "description": "The minimum power that the AP shall request from to the AFC controller.",
+                    "type": "number"
+                },
+                "frequency-ranges": {
+                    "description": "The list of frequency ranges that the AP shall request from to the AFC controller.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "operating-classes": {
+                    "description": "The list of frequency ranges that the AP shall request from to the AFC controller.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
         "radio": {
             "description": "Describe a physical radio on the AP. A radio is be parent to several VAPs. They all share the same physical properties.",
             "type": "object",
@@ -597,6 +647,9 @@
                 },
                 "he-settings": {
                     "$ref": "#/$defs/radio.he"
+                },
+                "he-6ghz-settings": {
+                    "$ref": "#/$defs/radio.he-6ghz"
                 },
                 "hostapd-iface-raw": {
                     "description": "This array allows passing raw hostapd.conf lines.",


### PR DESCRIPTION
Fixes WIFI-13641 : strict-forwarding for yuncore_fap655 and
    other similar devices where the wan_port is on the switch.
    Update the correct wan_port in /etc/config/event as part of the
    configuration update.