### PR TITLE
fix: modified code to use final as default for fingerprint mode

### DIFF
--- a/schema/service.fingerprint.yml
+++ b/schema/service.fingerprint.yml
@@ -10,7 +10,7 @@ properties:
     - polled
     - final
     - raw-data
-    default: always
+    default: final
   minimum-age:
     description:
       The minimum age a fingerprint must have before it is reported.

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -9188,7 +9188,7 @@ function instantiateServiceFingerprint(location, value, errors) {
 			obj.mode = parseMode(location + "/mode", value["mode"], errors);
 		}
 		else {
-			obj.mode = "always";
+			obj.mode = "final";
 		}
 
 		function parseMinimumAge(location, value, errors) {

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -4293,7 +4293,7 @@
                                 "final",
                                 "raw-data"
                             ],
-                            "default": "always"
+                            "default": "final"
                         },
                         "minimum-age": {
                             "description": "The minimum age a fingerprint must have before it is reported.",

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3258,7 +3258,7 @@
                         "final",
                         "raw-data"
                     ],
-                    "default": "always"
+                    "default": "final"
                 },
                 "minimum-age": {
                     "type": "number",

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -3739,7 +3739,7 @@
                         "final",
                         "raw-data"
                     ],
-                    "default": "always"
+                    "default": "final"
                 },
                 "minimum-age": {
                     "description": "The minimum age a fingerprint must have before it is reported.",


### PR DESCRIPTION
# Description

Correcting schema to use `final` as default value.
Details in:
https://telecominfraproject.atlassian.net/browse/WIFI-431

# Summary of changes:
- Modified code to use `final` as default value for fingerprint mode.