### PR TITLE
Fixing issues with section names in network config

### DIFF
--- a/renderer/templates/ethernet.uc
+++ b/renderer/templates/ethernet.uc
@@ -1,11 +1,12 @@
 {% let eth_ports = ethernet.lookup_by_select_ports(ports.select_ports) %}
-{% for (let port in eth_ports):
-	port = replace(port, '.', '_');
-%}
-set network.{{ port }}=device
-set network.{{ port }}.name={{ s(port) }}
-set network.{{ port }}.ifname={{ s(port) }}
-set network.{{ port }}.enabled={{ b(ports.enabled) }}
-{% if (!ports.speed) continue %}
-set network.{{ port }}.speed={{ ports.speed }}
+{% for (let port in eth_ports): %}
+{% let nport = replace(port, '.', '_'); %}
+set network.{{ nport }}=device
+set network.{{ nport }}.name={{ s(port) }}
+set network.{{ nport }}.ifname={{ s(port) }}
+set network.{{ nport }}.enabled={{ ports.enabled }}
+{% if (!ports.speed && !ports.duplex) continue %}
+set network.{{ nport }}.speed={{ ports.speed }}
+set network.{{ nport }}.duplex={{ ports.duplex == "full" ? true : false }}
+
 {% endfor %}

--- a/renderer/templates/interface/ieee8021x.uc
+++ b/renderer/templates/interface/ieee8021x.uc
@@ -7,10 +7,13 @@ set ieee8021x.@port[-1].upstream={{ b(interface.role == 'upstream') }}
 add_list ieee8021x.@port[-1].wan_ports={{ s(port) }}
 {%   endfor %}
 
-set network.{{ replace(port, '.', '_') }}=device
-set network.@device[-1].name={{ s(port) }}
-set network.@device[-1].auth='1'
-set network.@device[-1].auth_vlan={{ interface.dot1x_vlan }}:u
+{%
+	let nport = replace(port, '.', '_')
+%}
+set network.{{ s(nport) }}=device
+set network.{{ s(nport) }}.name={{ s(port) }}
+set network.{{ s(nport) }}.auth='1'
+set network.{{ s(nport) }}.auth_vlan={{ interface.dot1x_vlan }}:u
 
 {%   if (interface.role == 'upstream'): %}
 add_list network.up.ports={{ s(port) }}


### PR DESCRIPTION
In ethernet.uc, the section names are the same as that of interface names with . replaced by _ However name and ifname should still be the name with the . (dot). Fixed it. Interface with _ in the name does n't exist

In ieee8021x.uc , auth and aut_vlan should be updated on the already created section in the network and not on a new section. Otherwise a redundant device section would be created which is not correct.