### PR TITLE
fix 80211w value for "none" encryption

### DIFF
--- a/renderer/templates/interface/ssid.uc
+++ b/renderer/templates/interface/ssid.uc
@@ -203,7 +203,7 @@
 		if ('6G' in phy.band)
 			return 2;
 
-		if (!ssid.encryption)
+		if (!ssid.encryption || ssid.encryption.proto in [ "none" ])
 			return 0;
 
 		if (ssid.encryption.proto in [ "sae-mixed", "wpa3-mixed" ])


### PR DESCRIPTION
We treated ssid.encryption.proto = "none" in validate_encryption() as no encryption, we should do the same in match_ieee80211w().