### PR TITLE
flag to denote compressed commands (configure for now) are supported

### DIFF
--- a/system/capabilities.uc
+++ b/system/capabilities.uc
@@ -143,5 +143,7 @@ if (board.system?.label_macaddr)
 if (length(wifi))
 	capa.wifi = wifi;
 
+capa.compress_cmd = true;
+
 fs.writefile('/etc/ucentral/capabilities.json', capa);
 


### PR DESCRIPTION
Flag to denote that device supports compressed messages (configure only at the moment)
Relates to PR in [wlan-ucentral-client ](https://github.com/Telecominfraproject/wlan-ucentral-client/pull/3) and should not be pulled until that is also merged.