### PR TITLE
ucentral-schema: add support for configuring snmpd service using ucentral. WIFI-14152

### DIFF
--- a/renderer/templates/services/snmpd.uc
+++ b/renderer/templates/services/snmpd.uc
@@ -1,0 +1,73 @@
+{%
+
+if (!length(snmpd)) return;
+let interfaces = services.lookup_interfaces("snmpd");
+%}
+
+
+# SNMPD service configuration
+set snmpd.general.enabled={{ s(snmpd.general.enabled) }} 
+{% for (let interface in interfaces): %}
+{%    let name = ethernet.calculate_name(interface) %}
+add_list snmpd.general.network={{ name }}
+{% endfor %}
+
+
+add agent
+set snmpd.@agent[-1].agentaddress={{ s(snmpd.agent.agentaddress) }}
+
+add system
+set snmpd.@system[-1].sysLocation={{ s(snmpd.system.sysLocation) }}
+set snmpd.@system[-1].sysContact={{ s(snmpd.system.sysContact) }}
+set snmpd.@system[-1].sysName={{ s(snmpd.system.sysName) }}
+
+add agentx
+set snmpd.@agentx[-1].type={{ s(snmpd.agentx.type) }}
+
+{% for (let g, v in snmpd.group): %}
+set snmpd.{{g}}.group={{ s(v.group) }}
+set snmpd.{{g}}.version={{ s(v.version) }}
+set snmpd.{{g}}.secname={{ s(v.secname) }}
+{% endfor %}
+
+{% for (let n, v in snmpd.view): %}
+set snmpd.{{n}}.viewname={{ s(v.viewname) }}
+set snmpd.{{n}}.type={{ s(v.type) }}
+set snmpd.{{n}}.oid={{ s(v.oid) }}
+{% endfor %}
+
+{% for (let c, v in snmpd.com2sec): %}
+set snmpd.{{c}}.secname={{ s(v.secname) }}
+set snmpd.{{c}}.source={{ s(v.source) }}
+set snmpd.{{c}}.community={{ s(v.community) }}
+{% endfor %}
+
+{% for (let p, v in snmpd.pass): %}
+add snmpd pass
+set snmpd.@pass[-1].name={{ s(v.name) }}
+set snmpd.@pass[-1].miboid={{ s(v.miboid) }}
+set snmpd.@pass[-1].prog={{ s(v.prog) }}
+{% endfor %}
+
+{% for (let a, v in snmpd.access): %}
+add access
+set snmpd.{{a}}.context={{ s(v.context) }}
+set snmpd.{{a}}.version={{ s(v.version) }}
+set snmpd.{{a}}.level={{ s(v.level) }}
+set snmpd.{{a}}.prefix={{ s(v.prefix) }}
+set snmpd.{{a}}.read={{ s(v.read) }}
+set snmpd.{{a}}.write={{ s(v.write) }}
+set snmpd.{{a}}.notify={{ s(v.notify) }}
+set snmpd.{{a}}.group={{ s(v.group) }}
+{% endfor %}
+
+{% let port = split(snmpd.agent.agentaddress, ':')[1] %}
+{% for (let interface in interfaces): %}
+{%    let name = ethernet.calculate_name(interface) %}
+add firewall rule
+set firewall.@rule[-1].name='Allow SNMP'
+set firewall.@rule[-1].src={{ name }}
+set firewall.@rule[-1].dest_port={{port}}
+set firewall.@rule[-1].proto='udp'
+set firewall.@rule[-1].target='ACCEPT' 
+{% endfor %}

--- a/schema/service.snmpd.access.yml
+++ b/schema/service.snmpd.access.yml
@@ -1,0 +1,78 @@
+description:
+  List of access types for SNMP.
+type: object
+properties:
+  - public_access:
+      type: object
+      description:
+        Configuration of public access.
+      properties:
+        context:
+          description:
+            A collection of management information accessible by an SNMP entity.
+          type: string
+        group:
+          description:
+            Group related to the access.
+          type: string
+        level:
+          description:
+            Level of authorization.
+          type: string
+        notify:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string
+        prefix:
+          description:
+            Specifies how CONTEXT should be matched against the context of the incoming request.
+          type: string
+        read:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string
+        write:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string
+  - private_access:
+      type: object
+      description:
+        Configuration of public access.
+      properties:
+        context:
+          description:
+            A collection of management information accessible by an SNMP entity.
+          type: string
+        group:
+          description:
+            Group related to the access.
+          type: string
+        level:
+          description:
+            Level of authorization.
+          type: string
+        notify:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string
+        prefix:
+          description:
+            Specifies how CONTEXT should be matched against the context of the incoming request.
+          type: string
+        read:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string
+        write:
+          description:
+            Specifies the view to be used for GET*, SET and TRAP/INFORM requests.
+          type: string

--- a/schema/service.snmpd.agent.yml
+++ b/schema/service.snmpd.agent.yml
@@ -1,0 +1,9 @@
+description:
+  Configure the SNMP agent.
+type: object
+properties:
+  agentaddress:
+    description:
+      Define the agent configuration.
+    type: string
+    default: UDP:161

--- a/schema/service.snmpd.agentx.yml
+++ b/schema/service.snmpd.agentx.yml
@@ -1,0 +1,9 @@
+description:
+  Configure the role in AgentX protocol.
+type: object
+properties:
+  type:
+    description:
+      AgentX protocol role.
+    type: string
+    default: master

--- a/schema/service.snmpd.com2sec.yml
+++ b/schema/service.snmpd.com2sec.yml
@@ -1,0 +1,38 @@
+description:
+  Map an SNMPv1 or SNMPv2c community string to a security name..
+type: object
+properties:
+  - public:
+      description:
+        Public com2sec.
+      type: object
+      properties:
+        community:
+          description:
+            Community name.
+          type: string
+        secname:
+          description:
+            Security name.
+          type: string
+        source:
+          description:
+            A restricted source can either be a specific hostname or a subnet.
+          type: string
+  - private:
+      description:
+        Private com2sec.
+      type: object
+      properties:
+        community:
+          description:
+            Community name.
+          type: string
+        secname:
+          description:
+            Security name.
+          type: string
+        source:
+          description:
+            A restricted source can either be a specific hostname or a subnet.
+          type: string

--- a/schema/service.snmpd.general.yml
+++ b/schema/service.snmpd.general.yml
@@ -1,0 +1,9 @@
+description:
+  General options for SNMP service.
+type: object
+properties:
+  enabled:
+    description:
+      Enable or disable the service
+    type: boolean
+    default: false

--- a/schema/service.snmpd.group.yml
+++ b/schema/service.snmpd.group.yml
@@ -1,0 +1,64 @@
+description:
+  List of pass sections for SNMP.
+type: object
+properties:
+  - public_v1:
+      type: object
+      properties:
+        group:
+          type: string
+          description:
+            Group name.
+        secname:
+          description:
+            Related security name.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string
+  - private_v1:
+      type: object
+      properties:
+        group:
+          type: string
+          description:
+            Group name.
+        secname:
+          description:
+            Related security name.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string
+  - private_v2c:
+      type: object
+      properties:
+        group:
+          type: string
+          description:
+            Group name.
+        secname:
+          description:
+            Related security name.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string
+  - public_v2c:
+      type: object
+      properties:
+        group:
+          type: string
+          description:
+            Group name.
+        secname:
+          description:
+            Related security name.
+          type: string
+        version:
+          description:
+            SNMP version.
+          type: string

--- a/schema/service.snmpd.pass.yml
+++ b/schema/service.snmpd.pass.yml
@@ -1,0 +1,18 @@
+description:
+  List of community permissions.
+type: array
+items:
+  type: object
+  properties:
+      miboid:
+        description:
+          OID used by pass protocol.
+        type: string
+      name:
+        description:
+          Name of the MIB.
+        type: string
+      prog:
+        description:
+          MIB script.
+        type: string

--- a/schema/service.snmpd.system.yml
+++ b/schema/service.snmpd.system.yml
@@ -1,0 +1,16 @@
+description:
+  System information used by SNMP service.
+type: object
+properties:
+  sysContact:
+    description:
+      Contact information.
+    type: string
+  sysLocation:
+    description:
+      Location information.
+    type: string
+  sysName:
+    description:
+      System name.
+    type: string

--- a/schema/service.snmpd.view.yml
+++ b/schema/service.snmpd.view.yml
@@ -1,0 +1,16 @@
+description:
+  View configuration.
+type: object
+properties:
+    oid:
+      description:
+        Define the source oid tree for the view.
+      type: string
+    type:
+      description:
+        Type is either included or excluded.
+      type: string
+    viewname:
+      description:
+        View name.
+      type: string

--- a/schema/service.snmpd.yml
+++ b/schema/service.snmpd.yml
@@ -1,0 +1,22 @@
+description:
+  SNMP sections.
+type: object
+properties:
+  agent:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/agent/"
+  access:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/access/"
+  agentx:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/agentx/"
+  com2sec:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/com2sec/"
+  general:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/general/"
+  pass:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/pass/"
+  group:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/group/"
+  system:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/system/"
+  view:
+    $ref: "https://ucentral.io/schema/v1/service/snmpd/view/"

--- a/schema/service.yml
+++ b/schema/service.yml
@@ -49,3 +49,5 @@ properties:
     $ref: 'https://ucentral.io/schema/v1/service/rrm/'
   fingerprint:
     $ref: 'https://ucentral.io/schema/v1/service/fingerprint/'
+  snmpd:
+    $ref: 'https://ucentral.io/schema/v1/service/snmpd/'

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -9467,6 +9467,834 @@ function instantiateServiceFingerprint(location, value, errors) {
 	return value;
 }
 
+function instantiateServiceSnmpdAgent(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseAgentaddress(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "agentaddress")) {
+			obj.agentaddress = parseAgentaddress(location + "/agentaddress", value["agentaddress"], errors);
+		}
+		else {
+			obj.agentaddress = "UDP:161";
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdAccess(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parsePublic_access(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseContext(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "context")) {
+					obj.context = parseContext(location + "/context", value["context"], errors);
+				}
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseLevel(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "level")) {
+					obj.level = parseLevel(location + "/level", value["level"], errors);
+				}
+
+				function parseNotify(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "notify")) {
+					obj.notify = parseNotify(location + "/notify", value["notify"], errors);
+				}
+
+				function parsePrefix(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "prefix")) {
+					obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+				}
+
+				function parseRead(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "read")) {
+					obj.read = parseRead(location + "/read", value["read"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				function parseWrite(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "write")) {
+					obj.write = parseWrite(location + "/write", value["write"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "public_access")) {
+			obj.public_access = parsePublic_access(location + "/public_access", value["public_access"], errors);
+		}
+
+		function parsePrivate_access(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseContext(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "context")) {
+					obj.context = parseContext(location + "/context", value["context"], errors);
+				}
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseLevel(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "level")) {
+					obj.level = parseLevel(location + "/level", value["level"], errors);
+				}
+
+				function parseNotify(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "notify")) {
+					obj.notify = parseNotify(location + "/notify", value["notify"], errors);
+				}
+
+				function parsePrefix(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "prefix")) {
+					obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+				}
+
+				function parseRead(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "read")) {
+					obj.read = parseRead(location + "/read", value["read"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				function parseWrite(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "write")) {
+					obj.write = parseWrite(location + "/write", value["write"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "private_access")) {
+			obj.private_access = parsePrivate_access(location + "/private_access", value["private_access"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdAgentx(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseType(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "type")) {
+			obj.type = parseType(location + "/type", value["type"], errors);
+		}
+		else {
+			obj.type = "master";
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdCom2sec(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parsePublic(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseCommunity(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "community")) {
+					obj.community = parseCommunity(location + "/community", value["community"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseSource(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "source")) {
+					obj.source = parseSource(location + "/source", value["source"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "public")) {
+			obj.public = parsePublic(location + "/public", value["public"], errors);
+		}
+
+		function parsePrivate(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseCommunity(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "community")) {
+					obj.community = parseCommunity(location + "/community", value["community"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseSource(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "source")) {
+					obj.source = parseSource(location + "/source", value["source"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "private")) {
+			obj.private = parsePrivate(location + "/private", value["private"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdGeneral(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseEnabled(location, value, errors) {
+			if (type(value) != "bool")
+				push(errors, [ location, "must be of type boolean" ]);
+
+			return value;
+		}
+
+		if (exists(value, "enabled")) {
+			obj.enabled = parseEnabled(location + "/enabled", value["enabled"], errors);
+		}
+		else {
+			obj.enabled = false;
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdPass(location, value, errors) {
+	if (type(value) == "array") {
+		function parseItem(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseMiboid(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "miboid")) {
+					obj.miboid = parseMiboid(location + "/miboid", value["miboid"], errors);
+				}
+
+				function parseName(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "name")) {
+					obj.name = parseName(location + "/name", value["name"], errors);
+				}
+
+				function parseProg(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "prog")) {
+					obj.prog = parseProg(location + "/prog", value["prog"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+	}
+
+	if (type(value) != "array")
+		push(errors, [ location, "must be of type array" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdGroup(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parsePublic_v1(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "public_v1")) {
+			obj.public_v1 = parsePublic_v1(location + "/public_v1", value["public_v1"], errors);
+		}
+
+		function parsePrivate_v1(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "private_v1")) {
+			obj.private_v1 = parsePrivate_v1(location + "/private_v1", value["private_v1"], errors);
+		}
+
+		function parsePrivate_v2c(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "private_v2c")) {
+			obj.private_v2c = parsePrivate_v2c(location + "/private_v2c", value["private_v2c"], errors);
+		}
+
+		function parsePublic_v2c(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseGroup(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "group")) {
+					obj.group = parseGroup(location + "/group", value["group"], errors);
+				}
+
+				function parseSecname(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "secname")) {
+					obj.secname = parseSecname(location + "/secname", value["secname"], errors);
+				}
+
+				function parseVersion(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "version")) {
+					obj.version = parseVersion(location + "/version", value["version"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "public_v2c")) {
+			obj.public_v2c = parsePublic_v2c(location + "/public_v2c", value["public_v2c"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdSystem(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseSysContact(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "sysContact")) {
+			obj.sysContact = parseSysContact(location + "/sysContact", value["sysContact"], errors);
+		}
+
+		function parseSysLocation(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "sysLocation")) {
+			obj.sysLocation = parseSysLocation(location + "/sysLocation", value["sysLocation"], errors);
+		}
+
+		function parseSysName(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "sysName")) {
+			obj.sysName = parseSysName(location + "/sysName", value["sysName"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpdView(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseOid(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "oid")) {
+			obj.oid = parseOid(location + "/oid", value["oid"], errors);
+		}
+
+		function parseType(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "type")) {
+			obj.type = parseType(location + "/type", value["type"], errors);
+		}
+
+		function parseViewname(location, value, errors) {
+			if (type(value) != "string")
+				push(errors, [ location, "must be of type string" ]);
+
+			return value;
+		}
+
+		if (exists(value, "viewname")) {
+			obj.viewname = parseViewname(location + "/viewname", value["viewname"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceSnmpd(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		if (exists(value, "agent")) {
+			obj.agent = instantiateServiceSnmpdAgent(location + "/agent", value["agent"], errors);
+		}
+
+		if (exists(value, "access")) {
+			obj.access = instantiateServiceSnmpdAccess(location + "/access", value["access"], errors);
+		}
+
+		if (exists(value, "agentx")) {
+			obj.agentx = instantiateServiceSnmpdAgentx(location + "/agentx", value["agentx"], errors);
+		}
+
+		if (exists(value, "com2sec")) {
+			obj.com2sec = instantiateServiceSnmpdCom2sec(location + "/com2sec", value["com2sec"], errors);
+		}
+
+		if (exists(value, "general")) {
+			obj.general = instantiateServiceSnmpdGeneral(location + "/general", value["general"], errors);
+		}
+
+		if (exists(value, "pass")) {
+			obj.pass = instantiateServiceSnmpdPass(location + "/pass", value["pass"], errors);
+		}
+
+		if (exists(value, "group")) {
+			obj.group = instantiateServiceSnmpdGroup(location + "/group", value["group"], errors);
+		}
+
+		if (exists(value, "system")) {
+			obj.system = instantiateServiceSnmpdSystem(location + "/system", value["system"], errors);
+		}
+
+		if (exists(value, "view")) {
+			obj.view = instantiateServiceSnmpdView(location + "/view", value["view"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
 function instantiateService(location, value, errors) {
 	if (type(value) == "object") {
 		let obj = {};
@@ -9561,6 +10389,10 @@ function instantiateService(location, value, errors) {
 
 		if (exists(value, "fingerprint")) {
 			obj.fingerprint = instantiateServiceFingerprint(location + "/fingerprint", value["fingerprint"], errors);
+		}
+
+		if (exists(value, "snmpd")) {
+			obj.snmpd = instantiateServiceSnmpd(location + "/snmpd", value["snmpd"], errors);
 		}
 
 		return obj;

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -4391,6 +4391,300 @@
                             "default": false
                         }
                     }
+                },
+                "snmpd": {
+                    "description": "SNMP sections.",
+                    "type": "object",
+                    "properties": {
+                        "agent": {
+                            "description": "Configure the SNMP agent.",
+                            "type": "object",
+                            "properties": {
+                                "agentaddress": {
+                                    "description": "Define the agent configuration.",
+                                    "type": "string",
+                                    "default": "UDP:161"
+                                }
+                            }
+                        },
+                        "access": {
+                            "description": "List of access types for SNMP.",
+                            "type": "object",
+                            "properties": {
+                                "public_access": {
+                                    "type": "object",
+                                    "description": "Configuration of public access.",
+                                    "properties": {
+                                        "context": {
+                                            "description": "A collection of management information accessible by an SNMP entity.",
+                                            "type": "string"
+                                        },
+                                        "group": {
+                                            "description": "Group related to the access.",
+                                            "type": "string"
+                                        },
+                                        "level": {
+                                            "description": "Level of authorization.",
+                                            "type": "string"
+                                        },
+                                        "notify": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        },
+                                        "prefix": {
+                                            "description": "Specifies how CONTEXT should be matched against the context of the incoming request.",
+                                            "type": "string"
+                                        },
+                                        "read": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        },
+                                        "write": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "private_access": {
+                                    "type": "object",
+                                    "description": "Configuration of public access.",
+                                    "properties": {
+                                        "context": {
+                                            "description": "A collection of management information accessible by an SNMP entity.",
+                                            "type": "string"
+                                        },
+                                        "group": {
+                                            "description": "Group related to the access.",
+                                            "type": "string"
+                                        },
+                                        "level": {
+                                            "description": "Level of authorization.",
+                                            "type": "string"
+                                        },
+                                        "notify": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        },
+                                        "prefix": {
+                                            "description": "Specifies how CONTEXT should be matched against the context of the incoming request.",
+                                            "type": "string"
+                                        },
+                                        "read": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        },
+                                        "write": {
+                                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "agentx": {
+                            "description": "Configure the role in AgentX protocol.",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "description": "AgentX protocol role.",
+                                    "type": "string",
+                                    "default": "master"
+                                }
+                            }
+                        },
+                        "com2sec": {
+                            "description": "Map an SNMPv1 or SNMPv2c community string to a security name..",
+                            "type": "object",
+                            "properties": {
+                                "public": {
+                                    "type": "object",
+                                    "description": "Public com2sec.",
+                                    "properties": {
+                                        "community": {
+                                            "description": "Community name.",
+                                            "type": "string"
+                                        },
+                                        "secname": {
+                                            "description": "Security name.",
+                                            "type": "string"
+                                        },
+                                        "source": {
+                                            "description": "A restricted source can either be a specific hostname or a subnet.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "private": {
+                                    "description": "Private com2sec.",
+                                    "type": "object",
+                                    "properties": {
+                                        "community": {
+                                            "description": "Community name.",
+                                            "type": "string"
+                                        },
+                                        "secname": {
+                                            "description": "Security name.",
+                                            "type": "string"
+                                        },
+                                        "source": {
+                                            "description": "A restricted source can either be a specific hostname or a subnet.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "general": {
+                            "description": "General options for SNMP service.",
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable or disable the service",
+                                    "type": "boolean",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "pass": {
+                            "description": "List of community permissions.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "miboid": {
+                                        "description": "OID used by pass protocol.",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the MIB.",
+                                        "type": "string"
+                                    },
+                                    "prog": {
+                                        "description": "MIB script.",
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "group": {
+                            "description": "List of pass sections for SNMP.",
+                            "type": "object",
+                            "properties": {
+                                "public_v1": {
+                                    "type": "object",
+                                    "properties": {
+                                        "group": {
+                                            "type": "string",
+                                            "description": "Group name."
+                                        },
+                                        "secname": {
+                                            "description": "Related security name.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "private_v1": {
+                                    "type": "object",
+                                    "properties": {
+                                        "group": {
+                                            "type": "string",
+                                            "description": "Group name."
+                                        },
+                                        "secname": {
+                                            "description": "Related security name.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "private_v2c": {
+                                    "type": "object",
+                                    "properties": {
+                                        "group": {
+                                            "type": "string",
+                                            "description": "Group name."
+                                        },
+                                        "secname": {
+                                            "description": "Related security name.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "public_v2c": {
+                                    "type": "object",
+                                    "properties": {
+                                        "group": {
+                                            "type": "string",
+                                            "description": "Group name."
+                                        },
+                                        "secname": {
+                                            "description": "Related security name.",
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "description": "SNMP version.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "system": {
+                            "description": "System information used by SNMP service.",
+                            "type": "object",
+                            "properties": {
+                                "sysContact": {
+                                    "description": "Contact information.",
+                                    "type": "string"
+                                },
+                                "sysLocation": {
+                                    "description": "Location information.",
+                                    "type": "string"
+                                },
+                                "sysName": {
+                                    "description": "System name.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "view": {
+                            "description": "View configuration.",
+                            "type": "object",
+                            "properties": {
+                                "oid": {
+                                    "description": "Define the source oid tree for the view.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "Type is either included or excluded.",
+                                    "type": "string"
+                                },
+                                "viewname": {
+                                    "description": "View name.",
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3337,6 +3337,267 @@
                 }
             }
         },
+        "service.snmpd.agent": {
+            "type": "object",
+            "properties": {
+                "agentaddress": {
+                    "type": "string",
+                    "default": "UDP:161"
+                }
+            }
+        },
+        "service.snmpd.access": {
+            "type": "object",
+            "properties": {
+                "public_access": {
+                    "type": "object",
+                    "properties": {
+                        "context": {
+                            "type": "string"
+                        },
+                        "group": {
+                            "type": "string"
+                        },
+                        "level": {
+                            "type": "string"
+                        },
+                        "notify": {
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "read": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "write": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_access": {
+                    "type": "object",
+                    "properties": {
+                        "context": {
+                            "type": "string"
+                        },
+                        "group": {
+                            "type": "string"
+                        },
+                        "level": {
+                            "type": "string"
+                        },
+                        "notify": {
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "read": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "write": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.agentx": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "master"
+                }
+            }
+        },
+        "service.snmpd.com2sec": {
+            "type": "object",
+            "properties": {
+                "public": {
+                    "type": "object",
+                    "properties": {
+                        "community": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "private": {
+                    "type": "object",
+                    "properties": {
+                        "community": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.general": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "service.snmpd.pass": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "miboid": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "prog": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "service.snmpd.group": {
+            "type": "object",
+            "properties": {
+                "public_v1": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_v1": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_v2c": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "public_v2c": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string"
+                        },
+                        "secname": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.system": {
+            "type": "object",
+            "properties": {
+                "sysContact": {
+                    "type": "string"
+                },
+                "sysLocation": {
+                    "type": "string"
+                },
+                "sysName": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.snmpd.view": {
+            "type": "object",
+            "properties": {
+                "oid": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "viewname": {
+                    "type": "string"
+                }
+            }
+        },
+        "service.snmpd": {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "$ref": "#/$defs/service.snmpd.agent"
+                },
+                "access": {
+                    "$ref": "#/$defs/service.snmpd.access"
+                },
+                "agentx": {
+                    "$ref": "#/$defs/service.snmpd.agentx"
+                },
+                "com2sec": {
+                    "$ref": "#/$defs/service.snmpd.com2sec"
+                },
+                "general": {
+                    "$ref": "#/$defs/service.snmpd.general"
+                },
+                "pass": {
+                    "$ref": "#/$defs/service.snmpd.pass"
+                },
+                "group": {
+                    "$ref": "#/$defs/service.snmpd.group"
+                },
+                "system": {
+                    "$ref": "#/$defs/service.snmpd.system"
+                },
+                "view": {
+                    "$ref": "#/$defs/service.snmpd.view"
+                }
+            }
+        },
         "service": {
             "type": "object",
             "properties": {
@@ -3408,6 +3669,9 @@
                 },
                 "fingerprint": {
                     "$ref": "#/$defs/service.fingerprint"
+                },
+                "snmpd": {
+                    "$ref": "#/$defs/service.snmpd"
                 }
             }
         },

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -3833,6 +3833,327 @@
                 }
             }
         },
+        "service.snmpd.agent": {
+            "description": "Configure the SNMP agent.",
+            "type": "object",
+            "properties": {
+                "agentaddress": {
+                    "description": "Define the agent configuration.",
+                    "type": "string",
+                    "default": "UDP:161"
+                }
+            }
+        },
+        "service.snmpd.access": {
+            "description": "List of access types for SNMP.",
+            "type": "object",
+            "properties": {
+                "public_access": {
+                    "type": "object",
+                    "description": "Configuration of public access.",
+                    "properties": {
+                        "context": {
+                            "description": "A collection of management information accessible by an SNMP entity.",
+                            "type": "string"
+                        },
+                        "group": {
+                            "description": "Group related to the access.",
+                            "type": "string"
+                        },
+                        "level": {
+                            "description": "Level of authorization.",
+                            "type": "string"
+                        },
+                        "notify": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "description": "Specifies how CONTEXT should be matched against the context of the incoming request.",
+                            "type": "string"
+                        },
+                        "read": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        },
+                        "write": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_access": {
+                    "type": "object",
+                    "description": "Configuration of public access.",
+                    "properties": {
+                        "context": {
+                            "description": "A collection of management information accessible by an SNMP entity.",
+                            "type": "string"
+                        },
+                        "group": {
+                            "description": "Group related to the access.",
+                            "type": "string"
+                        },
+                        "level": {
+                            "description": "Level of authorization.",
+                            "type": "string"
+                        },
+                        "notify": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "description": "Specifies how CONTEXT should be matched against the context of the incoming request.",
+                            "type": "string"
+                        },
+                        "read": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        },
+                        "write": {
+                            "description": "Specifies the view to be used for GET*, SET and TRAP/INFORM requests.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.agentx": {
+            "description": "Configure the role in AgentX protocol.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "AgentX protocol role.",
+                    "type": "string",
+                    "default": "master"
+                }
+            }
+        },
+        "service.snmpd.com2sec": {
+            "description": "Map an SNMPv1 or SNMPv2c community string to a security name..",
+            "type": "object",
+            "properties": {
+                "public": {
+                    "type": "object",
+                    "description": "Public com2sec.",
+                    "properties": {
+                        "community": {
+                            "description": "Community name.",
+                            "type": "string"
+                        },
+                        "secname": {
+                            "description": "Security name.",
+                            "type": "string"
+                        },
+                        "source": {
+                            "description": "A restricted source can either be a specific hostname or a subnet.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "private": {
+                    "description": "Private com2sec.",
+                    "type": "object",
+                    "properties": {
+                        "community": {
+                            "description": "Community name.",
+                            "type": "string"
+                        },
+                        "secname": {
+                            "description": "Security name.",
+                            "type": "string"
+                        },
+                        "source": {
+                            "description": "A restricted source can either be a specific hostname or a subnet.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.general": {
+            "description": "General options for SNMP service.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable or disable the service",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "service.snmpd.pass": {
+            "description": "List of community permissions.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "miboid": {
+                        "description": "OID used by pass protocol.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the MIB.",
+                        "type": "string"
+                    },
+                    "prog": {
+                        "description": "MIB script.",
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "service.snmpd.group": {
+            "description": "List of pass sections for SNMP.",
+            "type": "object",
+            "properties": {
+                "public_v1": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "Group name."
+                        },
+                        "secname": {
+                            "description": "Related security name.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_v1": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "Group name."
+                        },
+                        "secname": {
+                            "description": "Related security name.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "private_v2c": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "Group name."
+                        },
+                        "secname": {
+                            "description": "Related security name.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "public_v2c": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "Group name."
+                        },
+                        "secname": {
+                            "description": "Related security name.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "SNMP version.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "service.snmpd.system": {
+            "description": "System information used by SNMP service.",
+            "type": "object",
+            "properties": {
+                "sysContact": {
+                    "description": "Contact information.",
+                    "type": "string"
+                },
+                "sysLocation": {
+                    "description": "Location information.",
+                    "type": "string"
+                },
+                "sysName": {
+                    "description": "System name.",
+                    "type": "string"
+                }
+            }
+        },
+        "service.snmpd.view": {
+            "description": "View configuration.",
+            "type": "object",
+            "properties": {
+                "oid": {
+                    "description": "Define the source oid tree for the view.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is either included or excluded.",
+                    "type": "string"
+                },
+                "viewname": {
+                    "description": "View name.",
+                    "type": "string"
+                }
+            }
+        },
+        "service.snmpd": {
+            "description": "SNMP sections.",
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "$ref": "#/$defs/service.snmpd.agent"
+                },
+                "access": {
+                    "$ref": "#/$defs/service.snmpd.access"
+                },
+                "agentx": {
+                    "$ref": "#/$defs/service.snmpd.agentx"
+                },
+                "com2sec": {
+                    "$ref": "#/$defs/service.snmpd.com2sec"
+                },
+                "general": {
+                    "$ref": "#/$defs/service.snmpd.general"
+                },
+                "pass": {
+                    "$ref": "#/$defs/service.snmpd.pass"
+                },
+                "group": {
+                    "$ref": "#/$defs/service.snmpd.group"
+                },
+                "system": {
+                    "$ref": "#/$defs/service.snmpd.system"
+                },
+                "view": {
+                    "$ref": "#/$defs/service.snmpd.view"
+                }
+            }
+        },
         "service": {
             "description": "This section describes all of the services that may be present on the AP. Each service is then referenced via its name inside an interface, ssid, ...",
             "type": "object",
@@ -3905,6 +4226,9 @@
                 },
                 "fingerprint": {
                     "$ref": "#/$defs/service.fingerprint"
+                },
+                "snmpd": {
+                    "$ref": "#/$defs/service.snmpd"
                 }
             }
         },


### PR DESCRIPTION
These changes make it possible to configure the snmpd service from the json file.

Example:

       "snmpd": {
	    "agent": {
		"agentaddress": "UDP:161"
	    },
            "access": {
		"private_access": {
                       "context": "none",
                       "group": private",
                       "level": "noauth",
                       "notify": "none",
                       "prefix": "exact",
                       "read": "all",
                       "version": "any",
                       "write": "none"
                },
		"public_access": {
                       "context": "none",                                                                
                       "group": "public",                                                                 
                       "level": "noauth",                                                                
                       "notify": "none",                                                                 
                       "prefix": "exact",                                                                
                       "read": "all",                                                                    
                       "version": "any",                                                                 
                       "write": "none"                                                                   
                } 
	    },
            "agentx": {
                "type": "master"
            },
            "com2sec": {
                "public": {
                        "community": "public",
                        "secname": "ro",
                        "source": "default"
                 },
                 "private": {
                        "community": "private",
                        "secname": "rw",
                        "source": "default"
                 }
            },
            "general": {
                "enabled": true,
            },
            "pass": [
                {                               
                        "miboid": ".1.3.6.1.1",
                        "name": "pass protocl",
                        "prog": "/bin/ash /etc/snmp/script.sh"
                },                       
            ], 
            "group": {
                "private_v2c": {
                        "group": "private",
                        "secname": "rw",
                        "version": "v2c"
                },
                "public_v2c": {
                        "group": "public",
                        "secname": "ro",
                        "version": "v2c"
                 }
            },
            "system": {
                "sysContact": "company.com",
                "sysLocation": "Spain",
                "sysName": "Host1"
            },
            "view": {
                "all": {
                        "oid": ".1",
                        "type": "included",
                        "viewname": "all"
                 }
            }
        }