### PR TITLE
system: Fix the delta_counters for dynamic vlan stations

### DIFF
--- a/system/state.uc
+++ b/system/state.uc
@@ -163,6 +163,9 @@ function ports_deltas(port) {
 
 function stations_deltas(assoc, iface) {
 	let ret = {};
+	// Search for the station in the dynamic iface
+	if (assoc.dynamic_vlan)
+		iface = iface + "-v" + assoc.dynamic_vlan;
 	if (!previous.stations[iface] || !previous.stations[iface][assoc.station])
 		return ret;
 	for (let k in [ "rx_packets", "tx_packets", "rx_bytes", "tx_bytes", "tx_retries", "tx_failed" ]) {


### PR DESCRIPTION
The stations connected to dynamic vlan send the `delta_counters` empty:

```
                                         "associations": [                                                                                                                                                          
                                                {                                                                                                                                                                  
                                                        "bssid": "c8:2c:2b:10:ee:80",                                                                                                                              
                                                        "station": "c2:63:1d:27:7a:f5",                                                                                                                            
                                                        "connected": 984,                                                                                                                                          
                                                        "inactive": 0,                                                                                                                                             
                                                        "tx_duration": 238526849,                                                                                                                                  
                                                        "rx_duration": 0,                                                                                                                                          
                                                        "rssi": -35,                                                                                                                                               
                                                        "ack_signal": -48,                                                                                                                                         
                                                        "ack_signal_avg": -43,                                                                                                                                     
                                                        "rx_packets": 516058,                                                                                                                                      
                                                        "tx_packets": 16758906,                                                                                                                                    
                                                        "rx_bytes": 34456428,                                                                                                                                      
                                                        "tx_bytes": 24198212679,                                                                                                                                   
                                                        "tx_retries": 0,                                                                                                                                           
                                                        "tx_failed": 13,                                                                                                                                           
                                                        "rx_rate": {                                                                                                                                               
                                                                "bitrate": 1200900,                                                                                                                                
                                                                "he": true,                                                                                                                                        
                                                                "mcs": 11,                                                                                                                                         
                                                                "nss": 2,                                                                                                                                          
                                                                "he_gi": 0,                                                                                                                                        
                                                                "he_dcm": 0,                                                                                                                                       
                                                                "chwidth": 80                                                                                                                                      
                                                        },                                                                                                                                                         
                                                        "tx_rate": {                                                                                                                                               
                                                                "bitrate": 6000,                                                                                                                                   
                                                                "chwidth": 20                                                                                                                                      
                                                        },                                                                                                                                                         
                                                        "dynamic_vlan": 4078,                                                                                                                                      
                                                        "delta_counters": {                                                                                                                                                                                                                                                                           
                                                        }                                                                                                                                                          
                                                }                                                                                                                                                                  
                                        ], 
```

This is because in the state.uc file, the `stations_deltas` function searches for the client on the main interface, ej. wlan0, instead of on the dynamic interface, ej. wlan0-v4078.
This change checks if the station is connected to a dynamic vlan and if it is true, searches for the client in the dynamic vlan interface.
 The syntax is the same  used to get the dynamic vlan id:

```
                            for (let k, v in stations) {                                                                                                                                                       
                                        let vlan = split(k, '-v');                                                                                                                                                 
                                        if (vlan[0] != vap.ifname)                                                                                                                                                 
                                                continue;                                                                                                                                                          
                                        if (vlan[1])                                                                                                                                                               
                                                for (let k, assoc in v)                                                                                                                                            
                                                        assoc.dynamic_vlan = +vlan[1];                                                                                                                             
                                        ssid.associations = [ ...(ssid.associations || []), ...v ];                                                                                                                
                                }        
```    