### PR TITLE
WIFI-14018: Allow option 82 DHCP fields to be transparently injected

### DIFF
--- a/renderer/templates/services/dhcp_inject.uc
+++ b/renderer/templates/services/dhcp_inject.uc
@@ -1,0 +1,28 @@
+{% if (!services.is_present("dhcpinject")) return %}
+{% let ssids = services.lookup_ssids("dhcpinject") %}
+{% let enable = length(ssids) %}
+{% services.set_enabled("dhcpinject", enable) %}
+{% 
+
+let ports;
+if (dhcp_inject && dhcp_inject.select_ports) {
+    ports = ethernet.lookup_by_select_ports(dhcp_inject.select_ports)
+}
+else {
+    ports = ["eth0"];
+}
+
+%}
+{% if (!enable) return %}
+
+# Dhcp Inject service configuration
+
+set dhcpinject.uplink=device
+{% for (let port in ports): %}
+add_list dhcpinject.uplink.port={{ port }}
+{% endfor %}
+
+set dhcpinject.ssids=ssids
+{% for (let ssid in ssids): %}
+add_list dhcpinject.ssids.ssid={{ s(ssid.name) }}
+{% endfor %}

--- a/schema/service.dhcp-inject.yml
+++ b/schema/service.dhcp-inject.yml
@@ -1,0 +1,11 @@
+description:
+  Define the interfaces on which the dhcp shall be relayed.
+type: object
+properties:
+  select-ports:
+    description:
+      The list of physical network devices that shall be used to fwd the
+      DHCP frames.
+    type: array
+    items:
+      type: string

--- a/schema/service.yml
+++ b/schema/service.yml
@@ -51,3 +51,5 @@ properties:
     $ref: 'https://ucentral.io/schema/v1/service/fingerprint/'
   snmpd:
     $ref: 'https://ucentral.io/schema/v1/service/snmpd/'
+  dhcp-inject:
+    $ref: 'https://ucentral.io/schema/v1/service/dhcp-inject/'

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -9083,39 +9083,6 @@ function instantiateServiceGps(location, value, errors) {
 	return value;
 }
 
-function instantiateServiceDhcpInject(location, value, errors) {
-	if (type(value) == "object") {
-		let obj = {};
-
-		function parseSelectPorts(location, value, errors) {
-			if (type(value) == "array") {                                                                                                                function parseItem(location, value, errors) {
-				if (type(value) != "string")
-					push(errors, [ location, "must be of type string" ]);
-
-				return value;
-				}
-
-				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
-			}
-
-			if (type(value) != "array")                                                                                                                  push(errors, [ location, "must be of type array" ]);
-
-			return value;
-		}
-
-		if (exists(value, "select-ports")) {
-			obj.select_ports = parseSelectPorts(location + "/select-ports", value["select-ports"], errors);
-		}
-
-		return obj;
-	}
-
-	if (type(value) != "object")
-			push(errors, [ location, "must be of type object" ]);
-
-	return value;
-}
-
 function instantiateServiceDhcpRelay(location, value, errors) {
 	if (type(value) == "object") {
 		let obj = {};
@@ -10356,6 +10323,41 @@ function instantiateServiceSnmpd(location, value, errors) {
 
 		if (exists(value, "view")) {
 			obj.view = instantiateServiceSnmpdView(location + "/view", value["view"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+		push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
+function instantiateServiceDhcpInject(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseSelectPorts(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "select-ports")) {
+			obj.select_ports = parseSelectPorts(location + "/select-ports", value["select-ports"], errors);
 		}
 
 		return obj;

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -9083,6 +9083,39 @@ function instantiateServiceGps(location, value, errors) {
 	return value;
 }
 
+function instantiateServiceDhcpInject(location, value, errors) {
+	if (type(value) == "object") {
+		let obj = {};
+
+		function parseSelectPorts(location, value, errors) {
+			if (type(value) == "array") {                                                                                                                function parseItem(location, value, errors) {
+				if (type(value) != "string")
+					push(errors, [ location, "must be of type string" ]);
+
+				return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")                                                                                                                  push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "select-ports")) {
+			obj.select_ports = parseSelectPorts(location + "/select-ports", value["select-ports"], errors);
+		}
+
+		return obj;
+	}
+
+	if (type(value) != "object")
+			push(errors, [ location, "must be of type object" ]);
+
+	return value;
+}
+
 function instantiateServiceDhcpRelay(location, value, errors) {
 	if (type(value) == "object") {
 		let obj = {};
@@ -10432,6 +10465,10 @@ function instantiateService(location, value, errors) {
 
 		if (exists(value, "snmpd")) {
 			obj.snmpd = instantiateServiceSnmpd(location + "/snmpd", value["snmpd"], errors);
+		}
+
+		if (exists(value, "dhcp-inject")) {
+			obj.dhcp_inject = instantiateServiceDhcpInject(location + "/dhcp-inject", value["dhcp-inject"], errors);
 		}
 
 		return obj;

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -4710,6 +4710,19 @@
                             }
                         }
                     }
+                },
+                "dhcp-inject": {
+                    "description": "Define the interfaces on which the dhcp shall be relayed.",
+                    "type": "object",
+                    "properties": {
+                        "select-ports": {
+                            "description": "The list of physical network devices that shall be used to fwd the DHCP frames.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3623,6 +3623,17 @@
                 }
             }
         },
+        "service.dhcp-inject": {
+            "type": "object",
+            "properties": {
+                "select-ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "service": {
             "type": "object",
             "properties": {
@@ -3697,6 +3708,9 @@
                 },
                 "snmpd": {
                     "$ref": "#/$defs/service.snmpd"
+                },
+                "dhcp-inject": {
+                    "$ref": "#/$defs/service.dhcp-inject"
                 }
             }
         },

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -4181,6 +4181,19 @@
                 }
             }
         },
+        "service.dhcp-inject": {
+            "description": "Define the interfaces on which the dhcp shall be relayed.",
+            "type": "object",
+            "properties": {
+                "select-ports": {
+                    "description": "The list of physical network devices that shall be used to fwd the DHCP frames.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "service": {
             "description": "This section describes all of the services that may be present on the AP. Each service is then referenced via its name inside an interface, ssid, ...",
             "type": "object",
@@ -4256,6 +4269,9 @@
                 },
                 "snmpd": {
                     "$ref": "#/$defs/service.snmpd"
+                },
+                "dhcp-inject": {
+                    "$ref": "#/$defs/service.dhcp-inject"
                 }
             }
         },


### PR DESCRIPTION
WIFI-14018: Allow option 82 DHCP fields to be transparently injected into client DHCP requests

  1. Added new service udhcpinject
  2. Modified schemareader.uc to parse dhcp-inject content

Signed-off-by: alex18_huang <alex18_huang@accton.com>

	new file:   renderer/templates/services/dhcp_inject.uc
	modified:   schemareader.uc