### PR TITLE
WIFI-14532: SSH IdleTimeout can be configured from JSON config

### DIFF
--- a/renderer/templates/services/ssh.uc
+++ b/renderer/templates/services/ssh.uc
@@ -18,7 +18,7 @@ files.add_named("/etc/dropbear/authorized_keys", join("\n", ssh.authorized_keys 
 set dropbear.@dropbear[-1].enable={{ b(enable) }}
 set dropbear.@dropbear[-1].Port={{ s(ssh.port) }}
 set dropbear.@dropbear[-1].PasswordAuth={{ b(ssh.password_authentication) }}
-set dropbear.@dropbear[-1].IdleTimeout=60
+set dropbear.@dropbear[-1].IdleTimeout={{ ssh.idle_timeout }}
 
 {% for (let interface in interfaces): %}
 {%    let name = ethernet.calculate_name(interface) %}

--- a/schema/service.ssh.yml
+++ b/schema/service.ssh.yml
@@ -25,3 +25,10 @@ properties:
       to false, only ssh key based authentication is possible.
     type: boolean
     default: true
+  idle-timeout:
+    description:
+      This option defines the idle timeout of an ssh connection, set to 0 to disable
+      this feature. Default to 60 seconds if this field is not specified.
+    type: integer
+    default: 60
+    maximum: 600

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -6844,6 +6844,26 @@ function instantiateServiceSsh(location, value, errors) {
 			obj.password_authentication = true;
 		}
 
+		function parseIdleTimeout(location, value, errors) {
+			if (type(value) in [ "int", "double" ]) {
+				if (value > 600)
+					push(errors, [ location, "must be lower than or equal to 600" ]);
+
+			}
+
+			if (type(value) != "int")
+				push(errors, [ location, "must be of type integer" ]);
+
+			return value;
+		}
+
+		if (exists(value, "idle-timeout")) {
+			obj.idle_timeout = parseIdleTimeout(location + "/idle-timeout", value["idle-timeout"], errors);
+		}
+		else {
+			obj.idle_timeout = 60;
+		}
+
 		return obj;
 	}
 

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -3048,6 +3048,12 @@
                             "description": "This option defines if password authentication shall be enabled. If set to false, only ssh key based authentication is possible.",
                             "type": "boolean",
                             "default": true
+                        },
+                        "idle-timeout": {
+                            "description": "This option defines the idle timeout of an ssh connection, set to 0 to disable this feature. Default to 60 seconds if this field is not specified.",
+                            "type": "integer",
+                            "default": 60,
+                            "maximum": 600
                         }
                     }
                 },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -2458,6 +2458,11 @@
                 "password-authentication": {
                     "type": "boolean",
                     "default": true
+                },
+                "idle-timeout": {
+                    "type": "integer",
+                    "default": 60,
+                    "maximum": 600
                 }
             }
         },

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -2801,6 +2801,12 @@
                     "description": "This option defines if password authentication shall be enabled. If set to false, only ssh key based authentication is possible.",
                     "type": "boolean",
                     "default": true
+                },
+                "idle-timeout": {
+                    "description": "This option defines the idle timeout of an ssh connection, set to 0 to disable this feature. Default to 60 seconds if this field is not specified.",
+                    "type": "integer",
+                    "default": 60,
+                    "maximum": 600
                 }
             }
         },


### PR DESCRIPTION
  Added support for ucentral config to specify ssh idle-timeout on device.