### PR TITLE
WIFI-14586: Halow spelling incorrect in ucentral-schema

### DIFF
--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -557,7 +557,7 @@
                             "5G-lower",
                             "5G-upper",
                             "6G",
-                            "Halow"
+                            "HaLow"
                         ]
                     },
                     "bandwidth": {
@@ -1511,7 +1511,7 @@
                                             "5G-lower",
                                             "5G-upper",
                                             "6G",
-                                            "Halow"
+                                            "HaLow"
                                         ]
                                     }
                                 },
@@ -4335,7 +4335,7 @@
                                     "5G-lower",
                                     "5G-upper",
                                     "6G",
-                                    "Halow"
+                                    "HaLow"
                                 ]
                             }
                         },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -475,7 +475,7 @@
                         "5G-lower",
                         "5G-upper",
                         "6G",
-                        "Halow"
+                        "HaLow"
                     ]
                 },
                 "bandwidth": {
@@ -2042,7 +2042,7 @@
                             "5G-lower",
                             "5G-upper",
                             "6G",
-                            "Halow"
+                            "HaLow"
                         ]
                     }
                 },
@@ -3291,7 +3291,7 @@
                             "5G-lower",
                             "5G-upper",
                             "6G",
-                            "Halow"
+                            "HaLow"
                         ]
                     }
                 },

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -532,7 +532,7 @@
                         "5G-lower",
                         "5G-upper",
                         "6G",
-                        "Halow"
+                        "HaLow"
                     ]
                 },
                 "bandwidth": {
@@ -2331,7 +2331,7 @@
                             "5G-lower",
                             "5G-upper",
                             "6G",
-                            "Halow"
+                            "HaLow"
                         ]
                     }
                 },
@@ -3775,7 +3775,7 @@
                             "5G-lower",
                             "5G-upper",
                             "6G",
-                            "Halow"
+                            "HaLow"
                         ]
                     }
                 },


### PR DESCRIPTION
  Run `generate.sh` to fix wrong `HaLow` spelling in ucentral.schema.*