### PR TITLE
Fix typo in enhanced MPSK property name

### DIFF
--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -735,7 +735,7 @@ let services = {
 			if (!interface.ssids)
 				continue;
 			for (let ssid in interface.ssids) {
-				if (!ssid?.enhanced-mpsk)
+				if (!ssid?.enhanced_mpsk)
 					continue;
 				if ((ssid?.encryption?.proto && type(ssid.encryption.proto) == 'string' &&
 				    ssid.encryption.proto == "mpsk-radius") ||


### PR DESCRIPTION
Corrected property key from `enhanced-mpsk` to `enhanced_mpsk`

Fixes: d8260f8 ("add property that allows disabling MPSK")
Fixes: WIFI-14484