### PR TITLE
WIFI-14739-set-halow-default-channel

### DIFF
--- a/renderer/templates/radio.uc
+++ b/renderer/templates/radio.uc
@@ -85,6 +85,10 @@
 
 	function match_channel(phy, radio) {
 		let wanted_channel = radio.channel;
+
+		if (radio.band == "HaLow" && !wanted_channel)
+			return 12;
+
 		if (!wanted_channel || wanted_channel == "auto")
 			return 0;
 


### PR DESCRIPTION
Set halow default channel to avoid HaLow not working when channel is not set in JSON.

Fixes: WIFI-14739