### PR TITLE
WIFI-14835-fix-phy0-cannot-be-detected

### DIFF
--- a/renderer/wifi/phy.uc
+++ b/renderer/wifi/phy.uc
@@ -183,7 +183,7 @@ function lookup_phys() {
 	let s1gMapping = map5GToS1G();
 
 	for (let phy in phys) {
-		if (!phy?.wiphy)
+		if (phy?.wiphy == null)
 			continue;
 		let phyname = 'phy' + phy.wiphy;
 		let path = paths[phyname];


### PR DESCRIPTION
Fix phy0 cannot be detected.
If only phy.wiphy is NULL, skip.

Fixes: WIFI-14835