### PR TITLE
Fix in interface.uc and ssid.uc to handle mesh settings based on the tunnel option defined in the schema

### DIFF
--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -203,6 +203,7 @@
 				ssid: { ...ssid, bss_mode: mode },
 				count,
 				name,
+				tunnel_proto,
 				network,
 			});
 			count++;

--- a/renderer/templates/interface/ssid.uc
+++ b/renderer/templates/interface/ssid.uc
@@ -400,7 +400,9 @@ set wireless.{{ section }}.owe_transition_ssid={{ s(ssid.name + '-OWE') }}
 set wireless.{{ section }}.mode={{ bss_mode }}
 set wireless.{{ section }}.mesh_id={{ s(ssid.name) }}
 set wireless.{{ section }}.mesh_fwding=0
+{%   if (tunnel_proto == 'mesh'): %}
 set wireless.{{ section }}.network=batman_mesh
+{%   endif %}
 set wireless.{{ section }}.mcast_rate=24000
 {%   endif %}
 


### PR DESCRIPTION

Fixes: WIFI-14950
https://telecominfraproject.atlassian.net/browse/WIFI-14950 