### PR TITLE
Update state.uc

### DIFF
--- a/system/state.uc
+++ b/system/state.uc
@@ -1016,7 +1016,7 @@ if (length(capab.network)) {
 				}
 			}
 
-			if (ports) {
+			if (ports && ports[iface]?.counters) {
 				state.counters = ports[iface].counters;
 				state.delta_counters = ports_deltas(iface);
 			}


### PR DESCRIPTION
Fix potential exception in state.uc (NOTE: udevmand *was* running during this)

root@d4babaa310c8:~# /usr/share/ucentral/state.uc
Reference error: left-hand side expression is null In /usr/share/ucentral/state.uc, line 1020, byte 35:

 `                state.counters = ports[iface].counters;`
  Near here ------------------------------------^