### PR TITLE
OLS-1027: sync: Syncup of port-mirror in switch section with OLS schema.

### DIFF
--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -510,19 +510,23 @@
             "type": "object",
             "properties": {
                 "port-mirror": {
-                    "description": "Enable mirror of traffic from multiple minotor ports to a single analysis port.",
-                    "type": "object",
-                    "properties": {
-                        "monitor-ports": {
-                            "description": "The list of ports that we want to mirror.",
-                            "type": "array",
-                            "items": {
+                    "description": "Enable port mirroring.",
+                    "type": "array",
+                    "items": {
+                        "description": "Enable mirror of traffic from multiple minotor ports to a single analysis port.",
+                        "type": "object",
+                        "properties": {
+                            "monitor-ports": {
+                                "description": "The list of ports that we want to mirror.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "analysis-port": {
+                                "description": "The port that mirror'ed packets should be sent to.",
                                 "type": "string"
                             }
-                        },
-                        "analysis-port": {
-                            "description": "The port that mirror'ed packets should be sent to.",
-                            "type": "string"
                         }
                     }
                 },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -329,16 +329,19 @@
             "type": "object",
             "properties": {
                 "port-mirror": {
-                    "type": "object",
-                    "properties": {
-                        "monitor-ports": {
-                            "type": "array",
-                            "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "monitor-ports": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "analysis-port": {
                                 "type": "string"
                             }
-                        },
-                        "analysis-port": {
-                            "type": "string"
                         }
                     }
                 },

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -364,19 +364,23 @@
             "type": "object",
             "properties": {
                 "port-mirror": {
-                    "description": "Enable mirror of traffic from multiple minotor ports to a single analysis port.",
-                    "type": "object",
-                    "properties": {
-                        "monitor-ports": {
-                            "description": "The list of ports that we want to mirror.",
-                            "type": "array",
-                            "items": {
+                    "description": "Enable port mirroring.",
+                    "type": "array",
+                    "items": {
+                        "description": "Enable mirror of traffic from multiple minotor ports to a single analysis port.",
+                        "type": "object",
+                        "properties": {
+                            "monitor-ports": {
+                                "description": "The list of ports that we want to mirror.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "analysis-port": {
+                                "description": "The port that mirror'ed packets should be sent to.",
                                 "type": "string"
                             }
-                        },
-                        "analysis-port": {
-                            "description": "The port that mirror'ed packets should be sent to.",
-                            "type": "string"
                         }
                     }
                 },


### PR DESCRIPTION
# Description

OLS schema allows array of port-mirror configurations for switches. Sync-up with WLAN schema.

More details in:
https://telecominfraproject.atlassian.net/browse/OLS-1027
