### PR TITLE
network: null-safety check and aggregate network ports from multiple sources

### DIFF
--- a/renderer/libs/ethernet.uc
+++ b/renderer/libs/ethernet.uc
@@ -124,7 +124,7 @@ function create_ethernet(capab, fs, swconfig) {
 			for (let k, v in lookup) {
 				/* tagged swconfig downstream ports are not allowed */
 				if (interface.role == 'downstream') {
-					if (this.swconfig && this.swconfig[k].switch && v == 'tagged')
+					if (this.swconfig && this.swconfig[k] && this.swconfig[k].switch && v == 'tagged')
 						warn('%s:%d - vlan tagging on downstream swconfig ports is not supported', this.swconfig[k]?.switch.name, this.swconfig[k].swconfig);
 					else
 						rv[k] = v;

--- a/system/capabilities.uc
+++ b/system/capabilities.uc
@@ -138,10 +138,23 @@ function swconfig_ports(device, role) {
 capa.network = {};
 macs = {};
 for (let k, v in board.network) {
-	if (v.ports)
-		capa.network[k] = v.ports;
+	let add_to_capa = (dev) => {
+		for (let p in swconfig_ports(dev, k)) {
+			if (index(capa.network[k], p) >= 0)
+				continue;
+			push(capa.network[k], p);
+		}
+	};
+
+	capa.network[k] = [];
+
+	if (v.ports) {
+		for (let port in v.ports) {
+			add_to_capa(port);
+		}
+	}
 	if (v.device)
-		capa.network[k] = swconfig_ports(v.device, k);
+		add_to_capa(v.device);
 	if (v.ifname)
 		capa.network[k] = split(replace(v.ifname, /^ */, ''), " ");
 	if (v.macaddr)


### PR DESCRIPTION
- Add null check for swconfig entry before accessing switch property in ethernet renderer to prevent runtime errors
- Refactor network capabilities loop to properly aggregate ports from both v.ports and v.device instead of overwriting, with deduplication via swconfig_ports()

Fixes: WIFI-15490