### PR TITLE
ucentral-schema: fix HaLow center frequency shows wrong in state.uc

### DIFF
--- a/system/state/halow.uc
+++ b/system/state/halow.uc
@@ -102,29 +102,24 @@ export function process_halow_radio(radio, survey_data) {
 		let bandwidth = s1g_info.s1g_bw;
 		radio.channel_width = bandwidth;
 
-		// Calculate lower and upper edge frequencies
-		// For S1G channels, lower edge = center_freq - bandwidth/2
-		let center_freq = s1g_info.s1g_freq;
-		let lower_freq = center_freq - bandwidth / 2;
-		let upper_freq = center_freq + bandwidth / 2;
-
-		// Update frequencies to include both lower and upper edge
-		radio.frequency = [lower_freq, upper_freq];
-
-		// Convert all channels
+		// Convert all channels and build corresponding frequency array
+		// (same format as 2.4G/5G: channels[] and frequency[] are 1:1 mapped)
 		let s1g_channels = [];
+		let s1g_frequencies = [];
 		for (let i = 0; i < length(orig_channels); i++) {
 			let ch = '' + orig_channels[i];
 			if (mapping_table[ch]) {
 				push(s1g_channels, mapping_table[ch].s1g_channel);
+				push(s1g_frequencies, mapping_table[ch].s1g_freq);
 			}
 		}
 		if (length(s1g_channels)) {
 			radio.channels = uniq(s1g_channels);
+			radio.frequency = uniq(s1g_frequencies);
 		}
 
-		// Update survey frequencies to match the S1G center frequency in MHz
-		let s1g_center_freq_khz = center_freq;
+		// Update survey frequencies to match the S1G center frequency
+		let survey_center_freq = s1g_info.s1g_freq;
 
 		// Collect survey items
 		radio.survey = [];
@@ -132,7 +127,7 @@ export function process_halow_radio(radio, survey_data) {
 			if (v.frequency in orig_frequency) {
 				// Make a copy of the survey item and update frequency
 				let survey_item = { ...v };
-				survey_item.frequency = s1g_center_freq_khz;
+				survey_item.frequency = survey_center_freq;
 				push(radio.survey, survey_item);
 			}
 		}


### PR DESCRIPTION
Fixes: WIFI-15501

Root Cause:
The state reporting code calculates HaLow frequency incorrectly. It computes lower and upper edge frequencies using center_freq minus/plus bandwidth/2, then reports those two edge values as the frequency array. This does not match the expected format where channels and frequencies should be 1-to-1 mapped, same as 2.4G and 5G radios. The survey frequency variable also uses this incorrect center_freq value.

Solution:
Replace the edge frequency calculation with a per-channel frequency lookup from the S1G mapping table. Build both s1g_channels and s1g_frequencies arrays in parallel, so each channel maps to its correct S1G center frequency. Update the survey frequency to use the mapped S1G frequency directly.