### PR TITLE
ucentral-schema: fix radio 2.4G/5G shows empty when HaLow radio exists

### DIFF
--- a/renderer/wifi/iface.uc
+++ b/renderer/wifi/iface.uc
@@ -60,8 +60,10 @@ function lookup_wifs() {
 	let rv = {};
 	for (let wif in wifs) {
 		let wif_obj = wif.mlo_links?.[0] || wif;
-		if (!wif_obj.wiphy_freq || !iftypes[wif.iftype])
+		if (!iftypes[wif.iftype])
 			continue;
+
+		// Allow interfaces with wiphy_freq=0 (e.g. NOHT/channel unknown state)
 		let w = {};
 		w.ssid = wif.ssid;
 		w.bssid = wif.mac;
@@ -69,11 +71,13 @@ function lookup_wifs() {
 		w.channel = [];
 		w.frequency = [];
 		w.tx_power = (wif_obj.wiphy_tx_power_level / 100) || 0;
-		for (let f in [ wif_obj.wiphy_freq, wif_obj.center_freq1, wif_obj.center_freq2 ])
-			if (f) {
-				push(w.channel, freq2channel(f));
-				push(w.frequency, f);
-			}
+		if (wif_obj.wiphy_freq) {
+			for (let f in [ wif_obj.wiphy_freq, wif_obj.center_freq1, wif_obj.center_freq2 ])
+				if (f) {
+					push(w.channel, freq2channel(f));
+					push(w.frequency, f);
+				}
+		}
 		if (chwidth[wif_obj.channel_width])
 			w.ch_width = chwidth[wif_obj.channel_width];
 		rv[wif.ifname] = w;

--- a/system/state/wifi.uc
+++ b/system/state/wifi.uc
@@ -77,16 +77,27 @@ export function collect_wifi_radios(state) {
 	for (let radio, data in wifistatus) {
 		if (!length(data.interfaces))
 			continue;
-		let vap = wifiiface[data.interfaces[0].ifname];
+
+		// Find first interface with valid frequency, fallback to first available
+		let vap;
+		for (let iface in data.interfaces) {
+			let v = wifiiface[iface.ifname];
+			if (length(v) && length(v.frequency)) {
+				vap = v;
+				break;
+			}
+		}
+		if (!vap)
+			vap = wifiiface[data.interfaces[0].ifname];
 		if (!length(vap))
 			continue;
 
 		let radio = {};
-		radio.channel = vap.channel[0];
-		radio.channels = uniq(vap.channel);
-		radio.frequency = uniq(vap.frequency);
-		radio.channel_width = +vap.ch_width;
-		radio.tx_power = vap.tx_power;
+		radio.channel = length(vap.channel) ? vap.channel[0] : 0;
+		radio.channels = uniq(vap.channel || []);
+		radio.frequency = uniq(vap.frequency || []);
+		radio.channel_width = +vap.ch_width || 0;
+		radio.tx_power = vap.tx_power || 0;
 
 		let path = data.config.path;
 		if (exists(data.config, 'radio'))


### PR DESCRIPTION
Fixes: WIFI-15504

Root Cause:
State reporting skips NOHT interfaces at ucentral-schema level: Once radios are in NOHT/DISABLED state with wiphy_freq=0, the iface.uc module skips them entirely. Then state.uc cannot find the interface data and skips the entire radio from the state report. Cloud only sees the HaLow radio which is functioning normally.

Solution: Remove the wiphy_freq=0 filter in iface.uc so interfaces with unknown channel are still reported. Modify state.uc to gracefully handle empty frequency arrays instead of skipping the radio.