### PR TITLE
[DHCP] fix DHCP-inject mechanism to prevent DHCP-inject cannot disabled

### DIFF
--- a/renderer/templates/services/dhcp_inject.uc
+++ b/renderer/templates/services/dhcp_inject.uc
@@ -68,6 +68,7 @@
 	}
 
 	// Main logic
+	services.set_enabled("dhcpinject", has_upstream_interfaces());
 	if (!has_dhcp_inject_interfaces())
 		return;
 %}


### PR DESCRIPTION
(ucentral part)
Root Cause:
When dhcp-inject is removed from SSID services, the renderer template (dhcp_inject.uc) does an early return before calling services.set_enabled("dhcpinject", ...). As a result, ucentral never knows it needs to stop the dhcpinject service — the process keeps running, tc filters remain, and option 82 continues to be injected until reboot.

Solution:
1.Move services.set_enabled() before the early return — so ucentral always registers the service state (enabled or disabled), and properly calls /etc/init.d/dhcpinject stop when disabled.
2.Add exit(0) after cleanup() in signal handler — ensures the process actually terminates after cleaning up tc filters (instead of potentially hanging in pcap_loop).
3.Add tc filter cleanup in stop_service() — safety net so filters are removed even if the process crashes or exits abnormally.

Fixes: WIFI-15562