### PR TITLE
health: add per-radio health check to detect failed SSIDs

### DIFF
--- a/renderer/wifi/iface.uc
+++ b/renderer/wifi/iface.uc
@@ -60,15 +60,20 @@ function lookup_wifs() {
 	let rv = {};
 	for (let wif in wifs) {
 		let wif_obj = wif.mlo_links?.[0] || wif;
-		if (!wif_obj.wiphy_freq || !iftypes[wif.iftype])
+		/* Don't filter on wiphy_freq here — interfaces with freq=0 (radio stuck
+		 * in NOHT/no-channel state) must remain visible so the health checker
+		 * can distinguish "radio present but broken" from "radio missing". */
+		if (!iftypes[wif.iftype])
 			continue;
 		let w = {};
 		w.ssid = wif.ssid;
 		w.bssid = wif.mac;
 		w.mode = iftypes[wif.iftype];
+		w.phy = wif.wiphy;
 		w.channel = [];
 		w.frequency = [];
 		w.tx_power = (wif_obj.wiphy_tx_power_level / 100) || 0;
+		w.has_channel = !!wif_obj.wiphy_freq;
 		for (let f in [ wif_obj.wiphy_freq, wif_obj.center_freq1, wif_obj.center_freq2 ])
 			if (f) {
 				push(w.channel, freq2channel(f));

--- a/system/health.uc
+++ b/system/health.uc
@@ -38,6 +38,193 @@ function find_ssid(ssid, wifi_state) {
 	return 1;
 }
 
+// Helper function: find SSID on a specific phy index
+function find_ssid_on_phy(ssid, phy_idx, wifi_state) {
+	for (let ifname, iface in wifi_state) {
+		if (iface.ssid == ssid && iface.phy == phy_idx) {
+			if (!iface.has_channel) {
+				return -1;
+			}
+			return 0;
+		}
+	}
+	return 1;
+}
+
+// Helper function: find SSID by interface name prefix
+function find_ssid_by_prefix(ssid, prefix, wifi_state) {
+	for (let ifname, iface in wifi_state) {
+		if (iface.ssid == ssid && index(ifname, prefix) == 0) {
+			if (!iface.has_channel) {
+				return -1;
+			}
+			return 0;
+		}
+	}
+	return 1;
+}
+
+// Helper function: find SSID on a specific phy filtered by band frequency range
+function find_ssid_on_phy_band(ssid, phy_idx, band, wifi_state) {
+	let band_ranges = {
+		'2g': [2400, 2500],
+		'5g': [5150, 5900],
+		'6g': [5925, 7200],
+	};
+	let range = band_ranges[band];
+	if (!range)
+		return find_ssid_on_phy(ssid, phy_idx, wifi_state);
+
+	for (let ifname, iface in wifi_state) {
+		if (iface.ssid != ssid || iface.phy != phy_idx)
+			continue;
+
+		/*
+		 * If interface has no channel (radio stuck), we can't verify band
+		 * by frequency. Match it anyway — it's on the right phy and SSID,
+		 * and no_channel is the more specific/useful error.
+		 */
+		if (!iface.has_channel)
+			return -1;
+
+		/* Check if any of the interface's frequencies fall within the expected band */
+		let in_band = false;
+		for (let f in iface.frequency) {
+			if (f >= range[0] && f <= range[1]) {
+				in_band = true;
+				break;
+			}
+		}
+		if (!in_band)
+			continue;
+
+		return 0;
+	}
+	return 1;
+}
+
+// Helper function: find SSID for a radio using match info
+function find_ssid_for_radio(ssid, match_info, wifi_state) {
+	if (match_info.match_mode == 'prefix')
+		return find_ssid_by_prefix(ssid, match_info.ifname_prefix, wifi_state);
+	else if (match_info.match_mode == 'phy_band')
+		return find_ssid_on_phy_band(ssid, match_info.phy_idx, match_info.band, wifi_state);
+	else
+		return find_ssid_on_phy(ssid, match_info.phy_idx, wifi_state);
+}
+
+// Helper function: get radio match info from device config
+function get_radio_match_info(section) {
+	if (!section || !section.path)
+		return null;
+
+	let info = {};
+
+	/* If device has ifname_prefix, use prefix-based matching (multi-radio single-phy chips) */
+	if (section.ifname_prefix) {
+		info.match_mode = 'prefix';
+		info.ifname_prefix = section.ifname_prefix;
+		return info;
+	}
+
+	/* Strip +N suffix used by multi-radio single-phy devices in UCI path */
+	let base_path = section.path;
+	let path_match = match(base_path, /^(.+)\+([0-9]+)$/);
+	if (path_match)
+		base_path = path_match[1];
+
+	/* Resolve phy index from sysfs path */
+	let phys = fs.glob(sprintf('/sys/devices/%s/ieee80211/phy*', base_path));
+	if (!length(phys))
+		phys = fs.glob(sprintf('/sys/devices/platform/%s/ieee80211/phy*', base_path));
+	if (!length(phys))
+		return null;
+
+	sort(phys);
+
+	/* If path had +N suffix, select the Nth phy under this device */
+	let phy_offset = path_match ? int(path_match[2]) : 0;
+	if (phy_offset >= length(phys))
+		return null;
+
+	let phy_name = fs.basename(phys[phy_offset]);
+	let phy_idx;
+
+	let idx_str = fs.readfile(sprintf('/sys/class/ieee80211/%s/index', phy_name));
+	if (idx_str != null) {
+		phy_idx = int(trim(idx_str));
+	} else {
+		let match_res = match(phy_name, /phy([0-9]+)/);
+		if (match_res)
+			phy_idx = int(match_res[1]);
+		else
+			return null;
+	}
+
+	/*
+	 * If the device has a 'radio' option, multiple wifi-devices share the same
+	 * phy (reconf-capable multi-band chips like EAP105). Use phy+band matching
+	 * to distinguish radios by their configured band.
+	 */
+	if (section.radio != null && section.band) {
+		info.match_mode = 'phy_band';
+		info.phy_idx = phy_idx;
+		info.band = section.band;
+		return info;
+	}
+
+	info.match_mode = 'phy';
+	info.phy_idx = phy_idx;
+	return info;
+}
+
+// Health check: Radio status
+function check_radio_health(wifi_config, wifi_state) {
+	let radio_issues = {};
+
+	for (let k, section in wifi_config) {
+		if (section['.type'] == 'wifi-device') {
+			let dev_name = section['.name'];
+			let disabled = section.disabled;
+
+			if (disabled == '1')
+				continue;
+
+			let match_info = get_radio_match_info(section);
+
+			if (match_info == null)
+				continue;
+
+			let expected_ssids = [];
+			for (let j, iface_section in wifi_config) {
+				if (iface_section['.type'] == 'wifi-iface' && iface_section.device == dev_name) {
+					push(expected_ssids, iface_section.ssid);
+				}
+			}
+
+			let failed_ssids = {};
+			for (let ssid in expected_ssids) {
+				let result = find_ssid_for_radio(ssid, match_info, wifi_state);
+				if (result != 0) {
+					failed_ssids[ssid] = (result == -1) ? 'no_channel' : 'missing';
+				}
+			}
+
+			if (length(failed_ssids)) {
+				radio_issues[dev_name] = {
+					failed_ssids: failed_ssids
+				};
+				if (match_info.match_mode == 'prefix')
+					radio_issues[dev_name].prefix = match_info.ifname_prefix;
+				else
+					radio_issues[dev_name].phy = match_info.phy_idx;
+			}
+		}
+	}
+
+	return radio_issues;
+}
+
 // Helper function: RADIUS probe
 function radius_probe(server, port, secret, user, pass) {
 	let f = fs.open('/tmp/radius.conf', 'w');
@@ -65,7 +252,7 @@ function check_dhcp_health(iface, config, dhcp) {
 	let device = iface.l3_device || iface.interface;
 	let warnings = [];
 	let health = {};
-	
+
 	let probe_dhcp = uci.get('network', iface.interface, 'dhcp_healthcheck') || false;
 
 	if (dhcp[name]?.leasetime && +config.dhcp_local)
@@ -79,9 +266,9 @@ function check_dhcp_health(iface, config, dhcp) {
 		if (rc) {
 			health.dhcp = false;
 			push(warnings, 'DHCP did not offer any leases');
-			ubus.call('event', 'event', { 
-				object: 'health', 
-				verb: 'dhcp', 
+			ubus.call('event', 'event', {
+				object: 'health',
+				verb: 'dhcp',
 				payload: { iface: name, error: 'DHCP did not offer any leases' }
 			});
 		}
@@ -90,12 +277,12 @@ function check_dhcp_health(iface, config, dhcp) {
 	return { health, warnings };
 }
 
-// Health check: DNS functionality  
+// Health check: DNS functionality
 function check_dns_health(iface, config, dhcp) {
 	let name = iface.interface;
 	let warnings = [];
 	let health = {};
-	
+
 	let probe_dns = false;
 
 	if (length(iface['dns-server']) && +config.dns_remote)
@@ -115,9 +302,9 @@ function check_dns_health(iface, config, dhcp) {
 			if (rc) {
 				health.dns = false;
 				push(warnings, `DNS ${ip} is not reachable`);
-				ubus.call('event', 'event', { 
-					object: 'health', 
-					verb: 'dns', 
+				ubus.call('event', 'event', {
+					object: 'health',
+					verb: 'dns',
 					payload: { iface: name, error: `DNS ${ip} is not reachable.` }
 				});
 			}
@@ -138,33 +325,33 @@ function check_wifi_health(iface, wifi_config, wifi_state) {
 	for (let k, wifi_iface in wifi_config) {
 		if (wifi_iface['.type'] != 'wifi-iface' || wifi_iface.network != name)
 			continue;
-			
+
 		// Check SSID availability
 		if (find_ssid(wifi_iface.ssid, wifi_state))
 			ssid[wifi_iface.ssid] = false;
-			
+
 		// Check RADIUS connectivity
-		if (wifi_iface.auth_server && 
-		    wifi_iface.auth_port && 
-		    wifi_iface.auth_secret && 
-		    wifi_iface.health_username && 
-		    wifi_iface.health_password && 
+		if (wifi_iface.auth_server &&
+		    wifi_iface.auth_port &&
+		    wifi_iface.auth_secret &&
+		    wifi_iface.health_username &&
+		    wifi_iface.health_password &&
 		    !wifi_iface.radius_gw_proxy) {
-			    
-			if (radius_probe(wifi_iface.auth_server, 
-			                wifi_iface.auth_port, 
-			                wifi_iface.auth_secret, 
-			                wifi_iface.health_username, 
+
+			if (radius_probe(wifi_iface.auth_server,
+			                wifi_iface.auth_port,
+			                wifi_iface.auth_secret,
+			                wifi_iface.health_username,
 			                wifi_iface.health_password)) {
-				                
+
 				radius[wifi_iface.ssid] = false;
-				push(warnings, sprintf('Radius %s:%s is not reachable', 
+				push(warnings, sprintf('Radius %s:%s is not reachable',
 					wifi_iface.auth_server, wifi_iface.auth_port));
-				ubus.call('event', 'event', { 
-					object: 'health', 
-					verb: 'radius', 
-					payload: { 
-						ssid: wifi_iface.ssid, 
+				ubus.call('event', 'event', {
+					object: 'health',
+					verb: 'radius',
+					payload: {
+						ssid: wifi_iface.ssid,
 						error: `Radius ${wifi_iface.auth_server}:${wifi_iface.auth_port} is not reachable` 
 					}
 				});
@@ -210,12 +397,12 @@ function check_memory_health() {
 		memory = memory.memory;
 		state.unit.memory = 100 - (memory.available * 100 / memory.total);
 		if (state.unit.memory >= 90)
-			ubus.call('event', 'event', { 
-				object: 'health', 
-				verb: 'memory', 
-				payload: { 
-					used: state.unit.memory, 
-					error: 'Memory is almost exhausted.' 
+			ubus.call('event', 'event', {
+				object: 'health',
+				verb: 'memory',
+				payload: {
+					used: state.unit.memory,
+					error: 'Memory is almost exhausted.'
 				}
 			});
 	}
@@ -235,7 +422,7 @@ function perform_interface_health_checks(configs) {
 			continue;
 
 		count++;
-		
+
 		let combined_health = {};
 		let all_warnings = [];
 
@@ -270,22 +457,43 @@ function perform_interface_health_checks(configs) {
 function main() {
 	// Load configurations
 	let configs = load_configs();
-	
+
 	// Perform all health checks
 	let interface_count = perform_interface_health_checks(configs);
 	check_rrm_health(configs.rrmd_config);
 	check_memory_health();
+
+	// Check radio health
+	let radio_issues = check_radio_health(configs.wifi_config, configs.wifi_state);
+	if (length(radio_issues)) {
+		state.radios = radio_issues;
+		for (let radio_name, issue in radio_issues) {
+			ubus.call('event', 'event', {
+				object: 'health',
+				verb: 'wifi',
+				payload: {
+					radio: radio_name,
+					error: sprintf('Radio %s has failed SSIDs', radio_name),
+					failed_ssids: issue.failed_ssids
+				}
+			});
+		}
+	}
 
 	// Calculate and report sanity
 	let errors = length(state.interfaces);
 	if (!errors)
 		delete state.interfaces;
 
-	let sanity = 100 - (errors * 100 / interface_count);
+	let radio_errors = length(radio_issues);
 
-	warn(printf('health check reports sanity of %d', sanity));
+	let total_checks = interface_count + length(configs.wifi_config);
+	let total_errors = errors + radio_errors;
+	let sanity = 100 - (total_errors * 100 / (total_checks || 1));
+
+	warn(printf('health check reports sanity of %d (iface_errors=%d, radio_errors=%d)', sanity, errors, radio_errors));
 	ubus.call('ucentral', 'health', {sanity: sanity, data: state});
-	
+
 	let f = fs.open("/tmp/ucentral.health", "w");
 	if (f) {
 		f.write({sanity: sanity, data: state});


### PR DESCRIPTION
Extend health metrics to verify each configured radio has its expected SSIDs operational. Detects two failure modes:
- 'missing': interface not present at all
- 'no_channel': interface exists but radio is stuck (no frequency assigned)

Support three device topologies:
- path+N suffix (multi-radio single-phy, e.g. EAP101)
- ifname_prefix based matching
- phy+band matching for reconf-capable shared-path devices (e.g. EAP105)

Radio errors are factored into the overall sanity score and reported via ubus health events.

In iface.uc, stop filtering out interfaces with wiphy_freq=0 so the health checker can distinguish broken radios from missing ones. Expose phy index and has_channel flag per interface.

Fixes: WIFI-15549