### PR TITLE
In the NAT mode the down bridge with all wlan member interfaces is in bridge_empty state

### DIFF
--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -12,6 +12,7 @@
 
 	const TUNNEL_PROTOCOLS = ['mesh', 'l2tp', 'vxlan', 'gre', 'gre6'];
 	const WDS_MODES = ['wds-sta', 'wds-ap'];
+	let eth_ports;
 
 	// Helper functions
 
@@ -222,12 +223,20 @@
 		return true;
 	}
 
+	function generate_bridge_empty_config() {
+		let output = [];
+		if (is_downstream_interface() && length(interface.ssids) > 0 && !has_ethernet_ports()) {
+			uci_comment(output, '### generate bridge_empty configuration');
+			uci_set_string(output, 'network.down.bridge_empty', '1');
+		}
+		return uci_output(output);
+	}
+
 	// Variables initialization (declare early for function access)
 	let has_downstream_relays = false;
 	let dest;
 	let this_vid;
 	let bss_modes;
-	let eth_ports;
 	let dot1x_ports;
 	let swconfig;
 
@@ -367,3 +376,6 @@
 {% if (tunnel_proto == 'mesh'): %}
 set network.{{ name }}.batman=1
 {% endif %}
+
+{{ generate_bridge_empty_config() }}
+


### PR DESCRIPTION
In the NAT mode ,after the bridge clears all wlan members when handling DEV_EVENT_REMOVE on netifd, the bridge fails to wake up again when a new member is added later.Therefore, the bridge must enter an empty state to remain active.

Fixes: WIFI-15442[RAP630c-311g]
https://telecominfraproject.atlassian.net/browse/WIFI-15442