### PR TITLE
trace: add snaplen and filter expression support

### DIFF
--- a/command/cmd_trace.uc
+++ b/command/cmd_trace.uc
@@ -42,6 +42,13 @@ if (!duration) {
 	push(command, '-c');
 	push(command, packets);
 }
+
+if (args.snaplen && +args.snaplen > 0)
+	push(command, '-s', +args.snaplen);
+
+if (args.filter && length(args.filter))
+	push(command, args.filter);
+
 let rc = system(command);
 
 if (rc != 0) {


### PR DESCRIPTION
## Summary

Adds two optional parameters to the `trace` command handler (`cmd_trace.uc`):

- **`snaplen`** — passed to `tcpdump -s <n>`, limits bytes captured per packet. Useful values: `96` (headers only), `512` (headers + small payloads), `65535` (full packet, tcpdump default). Without this, a 30-second capture on a busy interface produces 33–145 MB files that exceed the default upload limit.
- **`filter`** — BPF expression appended as the trailing `tcpdump` argument, e.g. `host 192.168.1.1 and port 443`. Must be last in the argv array per tcpdump's argument parsing rules.

Both parameters are optional. When absent, behavior is unchanged.

## Implementation

`cmd_trace.uc` builds the tcpdump command as a ucode array and calls `system(array)` — no shell is involved, so pushing additional argv elements is injection-safe by construction.

```javascript
if (args.snaplen && +args.snaplen > 0)
    push(command, '-s', +args.snaplen);

if (args.filter && length(args.filter))
    push(command, args.filter);
```

Invalid BPF expressions cause tcpdump to exit nonzero; the error surfaces through the standard WebSocket result channel.

## Testing

Tested end-to-end against an Aruba AP-325 running OpenWiFi firmware via a self-hosted OWGW (with matching gateway changes in [wlan-cloud-ucentralgw](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw)):

- `snaplen: 96, filter: "host 8.8.8.8"` → tcpdump ran with `-s 96 host 8.8.8.8`, returned pcap with capture length 96 ✓  
- No args → original command unchanged ✓

The companion gateway PR is at Telecominfraproject/wlan-cloud-ucentralgw and the UI PR is at Telecominfraproject/wlan-cloud-ucentralgw-ui.