### PR TITLE
network: add switch_vlan settings for models with LAN Ethernet ports

### DIFF
--- a/renderer/templates/interface/bridge-vlan.uc
+++ b/renderer/templates/interface/bridge-vlan.uc
@@ -187,7 +187,7 @@
 	}
 
 	function generate_switch_vlan_config() {
-		if (!swconfig)
+		if (is_vlan_configured() && !swconfig)
 			return '';
 
 		let output = [];


### PR DESCRIPTION
Root cause: 
The retrieval of switch_vlan follows these rules:
When interface.vlan.id is non-empty, the value is retrieved from swconfig. In this scenario, swconfig is mandatory and must be non-empty.
When interface.vlan.id is empty, the value is retrieved from ethernet.lookup_port, and swconfig is optional and not required.

Based on the above, the process should exit (or skip further processing) only when the following condition is met: interface.vlan.id is non-empty and switch_vlan is empty.

solution: In the function generate_switch_vlan_config of bridge-vlan.uc, exit processing should occur only when swconfig is null and is_vlan_configured is true.

fixes: WIFI-15570