### PR TITLE
radius_proxy: wire private_key_password into radsec TLS config

### DIFF
--- a/renderer/templates/services/radius_proxy.uc
+++ b/renderer/templates/services/radius_proxy.uc
@@ -42,6 +42,10 @@ function has_accounting_server(realm) {
 	return realm.acct_server;
 }
 
+function has_private_key_password(realm) {
+	return realm.private_key_password;
+}
+
 function get_radsec_certificates(idx, realm) {
 	let certs = {};
 	
@@ -75,7 +79,8 @@ function generate_radsec_realm_config(idx, realm, output) {
 	uci_set_string(output, 'radsecproxy.@tls[-1].CACertificateFile', certs.ca);
 	uci_set_string(output, 'radsecproxy.@tls[-1].certificateFile', certs.cert);
 	uci_set_string(output, 'radsecproxy.@tls[-1].certificateKeyFile', certs.key);
-	uci_set_string(output, 'radsecproxy.@tls[-1].certificateKeyPassword', '');
+	if (has_private_key_password(realm))
+		uci_set_string(output, 'radsecproxy.@tls[-1].certificateKeyPassword', realm.private_key_password);
 	
 	// Server configuration  
 	uci_named_section(output, sprintf('radsecproxy.server%d', idx), 'server');

--- a/tests/unit/services/radius_proxy/output/radius-proxy-mixed.uci
+++ b/tests/unit/services/radius_proxy/output/radius-proxy-mixed.uci
@@ -14,7 +14,6 @@ set radsecproxy.@tls[-1].name='tls0'
 set radsecproxy.@tls[-1].CACertificateFile='/etc/ssl/ca.pem'
 set radsecproxy.@tls[-1].certificateFile='/etc/ssl/cert.pem'
 set radsecproxy.@tls[-1].certificateKeyFile='/etc/ssl/key.pem'
-set radsecproxy.@tls[-1].certificateKeyPassword=
 set radsecproxy.server0=server
 set radsecproxy.@server[-1].name='server0'
 set radsecproxy.@server[-1].dynamicLookupCommand='/usr/libexec/naptr_lookup.sh'

--- a/tests/unit/services/radius_proxy/output/radius-proxy-radsec.uci
+++ b/tests/unit/services/radius_proxy/output/radius-proxy-radsec.uci
@@ -14,7 +14,6 @@ set radsecproxy.@tls[-1].name='tls0'
 set radsecproxy.@tls[-1].CACertificateFile='/tmp/mock/ca0'
 set radsecproxy.@tls[-1].certificateFile='/tmp/mock/cert0'
 set radsecproxy.@tls[-1].certificateKeyFile='/tmp/mock/key0'
-set radsecproxy.@tls[-1].certificateKeyPassword=
 set radsecproxy.server0=server
 set radsecproxy.@server[-1].name='server0'
 set radsecproxy.@server[-1].host='radius.example.com'


### PR DESCRIPTION
Fixes: WIFI-15387

Root Cause:
The radsec realm renderer always emitted `certificateKeyPassword` with an empty value, dropping any password supplied via the `private-key-password` schema field. That left users unable to ship encrypted client keys: radsecproxy could open the key file but never got the passphrase needed to decrypt it.

Solution:
Wire `realm.private_key_password` through with a `has_private_key_password()` helper and only emit the option when set, matching how the other optional radsec fields are handled.