### PR TITLE
state: fix HaLow center frequency in state message

### DIFF
--- a/system/state/halow.uc
+++ b/system/state/halow.uc
@@ -102,25 +102,31 @@ export function process_halow_radio(radio, survey_data) {
 		let bandwidth = s1g_info.s1g_bw;
 		radio.channel_width = bandwidth;
 
-		// Calculate lower and upper edge frequencies
-		// For S1G channels, lower edge = center_freq - bandwidth/2
+		// Report channels[] and frequency[] aligned 1:1, same as 2G/5G.
+		// 2G/5G push driver-reported channel/freq directly without collapsing,
+		// so controller can map the operating channel to its center frequency.
 		let center_freq = s1g_info.s1g_freq;
-		let lower_freq = center_freq - bandwidth / 2;
-		let upper_freq = center_freq + bandwidth / 2;
 
-		// Update frequencies to include both lower and upper edge
-		radio.frequency = [lower_freq, upper_freq];
-
-		// Convert all channels
-		let s1g_channels = [];
-		for (let i = 0; i < length(orig_channels); i++) {
-			let ch = '' + orig_channels[i];
-			if (mapping_table[ch]) {
-				push(s1g_channels, mapping_table[ch].s1g_channel);
+		if (bandwidth == 1) {
+			// 1MHz: driver only reports one channel
+			radio.frequency = [center_freq, center_freq];
+			radio.channels = [s1g_info.s1g_channel, s1g_info.s1g_channel];
+		} else {
+			// 2/4/8MHz: map each orig channel to S1G channel+freq, keep
+			// 1:1 aligned (do NOT uniq - same behaviour as 2G/5G).
+			let s1g_channels = [];
+			let s1g_frequencies = [];
+			for (let i = 0; i < length(orig_channels); i++) {
+				let ch = '' + orig_channels[i];
+				if (mapping_table[ch]) {
+					push(s1g_channels, mapping_table[ch].s1g_channel);
+					push(s1g_frequencies, mapping_table[ch].s1g_freq);
+				}
 			}
-		}
-		if (length(s1g_channels)) {
-			radio.channels = uniq(s1g_channels);
+			if (length(s1g_channels)) {
+				radio.channels = s1g_channels;
+				radio.frequency = s1g_frequencies;
+			}
 		}
 
 		// Update survey frequencies to match the S1G center frequency in MHz


### PR DESCRIPTION
Root Cause:
The state reporting code calculates HaLow frequency incorrectly. It computes lower and upper edge frequencies using center_freq minus/plus bandwidth/2, then reports those two edge values as the frequency array. This does not match the expected format where channels and frequencies should be 1-to-1 mapped, same as 2.4G and 5G radios. The survey frequency variable also uses this incorrect center_freq value.

Solution:
Replace the edge frequency calculation with a per-channel frequency lookup from the S1G mapping table. Build both s1g_channels and s1g_frequencies arrays in parallel, so each channel maps to its correct S1G center frequency. Update the survey frequency to use the mapped S1G frequency directly. (This new version fix can fix all 1/2/4/8M HaLow bandwidth)

Fixes: WIFI-15501