### PR TITLE
renderer/templates: Only force auto-channel when STA is on the same r…

### DIFF
--- a/renderer/templates/toplevel.uc
+++ b/renderer/templates/toplevel.uc
@@ -105,12 +105,26 @@
 	for (let i, radio in state.radios) {
 		if (!radio.channel || radio.channel == 'auto')
 			continue;
-		for (let j, iface in state.interfaces)
-			for (let s, ssid in iface.ssids)
-				if (ssid.bss_mode in [ 'sta', 'wds-sta', 'wds-repeater' ]) {
-					warn('Forcing Auto-Channel as a STA interface is present');
-					delete radio.channel;
+		let radio_phys = wiphy.lookup_by_band(radio.band);
+		let radio_sections = map(radio_phys, p => p.section);
+		for (let j, iface in state.interfaces) {
+			if (!radio.channel) break;
+			for (let s, ssid in (iface.ssids || [])) {
+				if (!radio.channel) break;
+				if (!(ssid.bss_mode in [ 'sta', 'wds-sta', 'wds-repeater' ]))
+					continue;
+				for (let band in (ssid.wifi_bands || [])) {
+					if (!radio.channel) break;
+					for (let phy in wiphy.lookup_by_band(band)) {
+						if (phy.section in radio_sections) {
+							warn('Forcing Auto-Channel as a STA interface is present on radio%d (%s)', i, radio.band);
+							delete radio.channel;
+							break;
+						}
+					}
 				}
+			}
+		}
 	}
 
 	include('base.uc');


### PR DESCRIPTION
…adio

Use wiphy.lookup_by_band() to resolve both the radio's band and the SSID's wifi_bands to phy sections, then check for overlap. This fixes the case where a radio labelled '5G-lower' would not match an SSID with wifi_bands=['5G'], since lookup_by_band already normalises 5G-lower/5G-upper into 5G via frequency range intersection.

Also guard against missing ssids/wifi_bands arrays and add early-exit once auto-channel has been forced to avoid duplicate warnings.

Fixes: WIFI-15569

---
Same as https://github.com/Telecominfraproject/wlan-ucentral-schema/pull/102 but for 4.2.0 LTS branch