### PR TITLE
renderer: fall back to interface wiphy when the link object has none

### DIFF
--- a/renderer/wifi/iface.uc
+++ b/renderer/wifi/iface.uc
@@ -68,7 +68,7 @@ function lookup_wifs() {
 		w.ssid = wif.ssid;
 		w.bssid = wif.mac;
 		w.mode = iftypes[wif.iftype];
-		w.phy = wif_obj.wiphy;
+		w.phy = wif_obj.wiphy ?? wif.wiphy;
 		w.channel = [];
 		w.frequency = [];
 		w.tx_power = (wif_obj.wiphy_tx_power_level / 100) || 0;


### PR DESCRIPTION
On MLO capable radios the objects in mlo_links carry only link level attributes (wiphy_freq, channel_width, center_freq1) and do not include the wiphy index. lookup_wifs() reads the phy from the link object, so w.phy ends up null even though the interface level object carries a valid wiphy. The health script then compares the phy of the configured section against the phy reported in state and flags a mismatch for every SSID on such radios.

Fall back to the interface level wiphy when the link object does not provide one.

Tested on EAP105, verified w.phy is populated and the health script no longer reports a section vs state phy mismatch.

Fixes: WIFI-15606