### PR TITLE
topology: guard against null port entry in collect_link_state

### DIFF
--- a/system/state/topology.uc
+++ b/system/state/topology.uc
@@ -128,7 +128,7 @@ export function collect_link_state(state) {
 				}
 			}
 
-			if (global.ports && global.ports[iface].counters) {
+			if (global.ports && global.ports[iface] && global.ports[iface].counters) {
 				port_state.counters = global.ports[iface].counters;
 				port_state.delta_counters = telemetry_module.ports_deltas(iface, global.ports, global.previous);
 			}


### PR DESCRIPTION
global.ports[iface] can be null for interfaces without a matching port entry (e.g. VLAN-remapped switch ports). Accessing .counters on it threw "left-hand side expression is null". Add an existence check before dereferencing.

Fixes: WIFI-15547