### PR TITLE
renderer: fix misplaced var in interface.uc breaking wireless bring-up

### DIFF
--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -12,6 +12,8 @@
 
 	const TUNNEL_PROTOCOLS = ['mesh', 'l2tp', 'vxlan', 'gre', 'gre6'];
 	const WDS_MODES = ['wds-sta', 'wds-ap'];
+	let eth_ports;
+	let bridgedev;
 
 	// Helper functions
 
@@ -236,7 +238,6 @@
 	let dest;
 	let this_vid;
 	let bss_modes;
-	let eth_ports;
 	let dot1x_ports;
 	let swconfig;
 
@@ -275,7 +276,7 @@
 
 	// Compute interface names and configuration
 	let name = ethernet.calculate_name(interface);
-	let bridgedev = normalize_bridge_device();
+	bridgedev = normalize_bridge_device();
 	let netdev = name;
 	let network = name;
 


### PR DESCRIPTION
Problem:
Since the bridge 'down' doesn't exist, hostapd can't add the wireless interface to it, which prevents the wireless interface from coming up.

Root cause:
The bridgedev and eth_ports variables were defined incorrectly in interface.uc, causing bridgedev to receive a null value. This prevented the generate_bridge_empty function from setting the bridge_empty parameter correctly. As a result, the 'down' bridge was not created, and the wireless interface could not be added to the bridge, leaving it unable to come up.

Solution:
Relocate the bridgedev and eth_ports variable definitions to the proper position in interface.uc.

Fixes: WIFI-15629