### PR TITLE
renderer: fix PPPoE username in Maverick mode

### DIFF
--- a/renderer/templates/broadband.uc
+++ b/renderer/templates/broadband.uc
@@ -36,7 +36,7 @@ if (broadband.protocol == "pppoe") {
 	let pppoe = { };
 
 	pppoe.protocol = 'pppoe';
-	pppoe.username = broadband['user-name'] || '';
+	pppoe.user_name = broadband['user-name'] || '';
 	pppoe.password = broadband.password || '';
 	pppoe.timeout = broadband.timeout || '30';
 


### PR DESCRIPTION
Problem:
The AP cannot obtain an IP address when the WAN IP mode is set to PPPoE in Maverick mode.PPPoE user name is not set in the /etc/config/network.

Root Cause:
In templates/broadband.uc, the broadband user-name is assigned to uplink.broad_band.username. However, templates/interface/broadband.uc expects interface.broad_band.user_name, which remains empty. This field name mismatch prevents the PPPoE username from being written to /etc/config/network.

Solution:
Rename the field in uplink.broad_band from username to user_name so that it matches what the interface template expects.

Tests: Successfully verified on RAP630C-311A

Fixes: WIFI-15336