### PR TITLE
command: fix wifiscan scanning every channel on each trigger

### DIFF
--- a/command/cmd_wifiscan.uc
+++ b/command/cmd_wifiscan.uc
@@ -12,6 +12,7 @@ if (!ctx) {
 }
 
 const SCAN_FLAG_AP = (1<<2);
+const CHANNEL_DWELL = 1000;
 const frequency_list_2g = [ 2412, 2417, 2422, 2427, 2432, 2437, 2442,
 			  2447, 2452, 2457, 2462, 2467, 2472, 2484 ];
 const frequency_list_5g = { '3': [ 5180, 5260, 5500, 5580, 5660, 5745 ],
@@ -78,9 +79,7 @@ function scan_trigger(wdev, frequency, width) {
 		params.scan_frequencies = frequency;
 	}
 	else if (frequency && width) {
-		params.wiphy_freq = frequency;
-		params.center_freq1 = frequency + frequency_offset[width];
-		params.channel_width = frequency_width[width];
+		params.scan_frequencies = [ frequency ];
 	}
 
 	if (active)
@@ -105,9 +104,28 @@ function scan_trigger(wdev, frequency, width) {
 		warn("Scan aborted by kernel\n");
 }
 
+/* merge scan results by BSSID, the kernel expires them while we are still sweeping */
+let bss_seen = {};
+
+function collect_scan(dev) {
+	let res = nl.request(def.NL80211_CMD_GET_SCAN, def.NLM_F_DUMP, { dev });
+
+	for (let entry in res || [])
+		if (entry?.bss?.bssid)
+			bss_seen[entry.bss.bssid] = entry;
+}
+
 function trigger_scan_width(wdev, freqs, width) {
-	for (let freq in freqs)
-		scan_trigger(wdev, freq, width);
+	for (let freq in freqs) {
+		/* scan_trigger() returns false rather than die()ing once #128 lands,
+		 * so a radio that cannot scan would otherwise still burn
+		 * CHANNEL_DWELL on every frequency in the list.
+		 */
+		if (scan_trigger(wdev, freq, width) === false)
+			continue;
+		collect_scan(wdev);
+		sleep(CHANNEL_DWELL);
+	}
 }
 
 function phy_get(wdev) {
@@ -174,9 +192,13 @@ function wifi_scan() {
 
 		printf("scanning on phy%d\n", phy.wiphy);
 
+		bss_seen = {};
+
 		let freqs = phy_get_frequencies(phy);
-		if (length(intersect(freqs, frequency_list_2g)))
+		if (length(intersect(freqs, frequency_list_2g))) {
 			scan_trigger(iface.dev, frequency_list_2g);
+			collect_scan(iface.dev);
+		}
 
 		let ch_width = iface.channel_width;
 		if (frequency_width[bandwith])
@@ -189,7 +211,8 @@ function wifi_scan() {
 			}
 			trigger_scan_width(iface.dev, freqs_5g, ch_width);
 		}
-		let res = nl.request(def.NL80211_CMD_GET_SCAN, def.NLM_F_DUMP, { dev: iface.dev });
+		collect_scan(iface.dev);
+		let res = values(bss_seen);
 		for (let bss in res) {
 			bss = bss.bss;
 			let res = {


### PR DESCRIPTION
Fixes: WIFI-14822

Root Cause:

`scan_trigger()` described a single-channel scan with `wiphy_freq`, but `NL80211_CMD_TRIGGER_SCAN` does not consume `NL80211_ATTR_WIPHY_FREQ` — that attribute configures an operating channel, it is not a scan parameter. Netlink silently ignores attributes a command does not use, so the request was accepted and the scan succeeded, while the kernel, finding no `scan_frequencies`, fell back to scanning every supported channel.

`trigger_scan_width()` therefore triggered a full-band sweep on each of its iterations instead of visiting one channel. On a 5 GHz radio at 80 MHz that is 6 iterations × 28 channels = 168 channel visits, chained with no return to the operating channel. That is the ~23 s outage reported in the ticket.

Measured directly on the device:

```
wiphy_freq: 5180            -> kernel scanned 28 channel(s)
scan_frequencies: [ 5180 ]  -> kernel scanned  1 channel(s)
```

This also explains two earlier findings on the ticket that did not add up: toggling active/passive made no difference (the problem is structural, not scan type), and the mac80211 dwell reduction helped without resolving it (it shrinks per-channel cost, not the six-fold multiplication).

Solution:

Four changes, all in `command/cmd_wifiscan.uc`:

1. Pass `scan_frequencies` so a single-channel scan really is one channel.
2. Use the full 5 GHz frequency list. The width-keyed list is only six channels at 80 MHz; full coverage was previously obtained by accident, as a side effect of the bug.
3. Dwell on the operating channel between visits. Without this the loop fires the next scan immediately, and 28 chained single-channel scans are indistinguishable from one 28-channel sweep — the outage and the deassociation both return.
4. Collect results after each channel and merge by BSSID. The kernel expires cached BSSes after roughly 30 s while a full sweep takes longer, so a single `GET_SCAN` after the sweep dropped whichever channels were scanned first.

Items 3 and 4 are both required; each was verified to be load-bearing by testing without it.

Testing:

YunCore AX820, client associated on 5 GHz running continuous traffic, `metrics.wifi-scan` enabled.

| | client impact | 5 GHz coverage |
|---|---|---|
| before | 23 s outage per scan, STA deassociates | full (side effect of the bug) |
| after | max 50 ms inactivity, no disassociation | all 17 frequencies that have neighbours |

Verified end to end on the OWGW Kafka `wifiscan` topic rather than only on the device: the report reaching the controller carries 73 BSS entries — 24 × 2.4 GHz and 49 × 5 GHz across the same 17 frequencies an exhaustive manual scan finds. Net airtime is 28 channel visits per scan interval instead of 168.

Notes:

`rrmd`'s `scan()` in `scan.uc` uses the identical `wiphy_freq` construct, so its per-tick background scan is also a full-band sweep. That needs the same correction and is tracked separately — it is out of scope for this repo.

This targets `main-v4.2.0-LTS` because that is where the fix was validated. `main` carries the same defect and needs the same change.

`staging-WIFI-15235-fix-wifi-scan1` also touches this file (bandwidth key type, `die()` on trigger failure, HaLow phy skip). The changes here are disjoint from those, but the two will need ordering if both land.
