### PR TITLE
renderer: dhcp_inject: enable per-SSID scoping, skip SSIDs without dh…

### DIFF
--- a/renderer/templates/services/dhcp_inject.uc
+++ b/renderer/templates/services/dhcp_inject.uc
@@ -17,6 +17,7 @@ set dhcpinject.{{ upstream.name }}=network
 set dhcpinject.{{ upstream.name }}.upstream={{ s(iface_name) }}
 
 {%    for (let ssid in upstream.ssids): %}
+{%       if (!ssid.services || index(ssid.services, "dhcp-inject") < 0) continue; %}
 {%       count += length(ssid.wifi_bands) %}
 {%       for (let freq in ssid.wifi_bands): %}
 {%          push(freqs, freq) %}


### PR DESCRIPTION
…cp-inject

The renderer added every SSID on an upstream to /etc/config/dhcpinject whenever any SSID on that interface enabled dhcp-inject, so an SSID with services:[] still got Option 82 injected. Skip SSIDs whose services list does not contain "dhcp-inject".

Fixes: WIFI-15626