### PR TITLE
cmd_wifiscan: restrict scan to the requested frequency

### DIFF
--- a/command/cmd_wifiscan.uc
+++ b/command/cmd_wifiscan.uc
@@ -78,9 +78,8 @@ function scan_trigger(wdev, frequency, width) {
 		params.scan_frequencies = frequency;
 	}
 	else if (frequency && width) {
-		params.wiphy_freq = frequency;
 		params.center_freq1 = frequency + frequency_offset[width];
-		params.channel_width = frequency_width[width];
+		params.scan_frequencies = [ (int) (frequency) ];
 	}
 
 	if (active)


### PR DESCRIPTION
The single-channel branch of scan_trigger() set wiphy_freq/center_freq1/ channel_width but never populated scan_frequencies, so the TRIGGER_SCAN request scanned the whole band instead of the requested channel.

Fixes: WIFI-14822