### PR TITLE
state: fix stale client IP reported after SSID is moved to another ne…

### DIFF
--- a/system/state/interfaces.uc
+++ b/system/state/interfaces.uc
@@ -129,7 +129,8 @@ export function collect(state) {
 
 				let client = {};
 
-				if (length(global.ip4leases[mac]))
+				if (length(global.ip4leases[mac]) &&
+				    network_module.lease_matches_iface(global.ip4leases[mac], iface))
 					push(ipv4leases, global.ip4leases[mac]);
 
 				client.mac = mac;

--- a/system/state/network.uc
+++ b/system/state/network.uc
@@ -113,3 +113,34 @@ export function prepare_dhcp_leases() {
 	return ip4leases;
 };
 
+/* only trust a local dnsmasq lease if its address falls inside one of the
+ * interface's own IPv4 subnets - a stale lease (e.g. left behind after an
+ * SSID was moved to another network) would otherwise shadow the address
+ * snooped from the real dhcp exchange */
+export function lease_matches_iface(lease, iface) {
+	if (!length(iface.ipv4.addresses))
+		return true;
+
+	let ip = iptoarr(lease.address);
+
+	if (length(ip) != 4)
+		return false;
+
+	for (let cidr in iface.ipv4.addresses) {
+		let net = split(cidr, "/");
+		let sub = iptoarr(net[0]);
+		let bits = net[1] ? int(net[1]) : -1;
+
+		if (length(sub) != 4 || bits < 0 || bits > 32)
+			continue;
+
+		let mask = (0xffffffff << (32 - bits)) & 0xffffffff;
+
+		if ((((ip[0] << 24) | (ip[1] << 16) | (ip[2] << 8) | ip[3]) & mask) ==
+		    (((sub[0] << 24) | (sub[1] << 16) | (sub[2] << 8) | sub[3]) & mask))
+			return true;
+	}
+
+	return false;
+};
+

--- a/system/state/topology-mac.uc
+++ b/system/state/topology-mac.uc
@@ -231,11 +231,15 @@ function parseDhcpLeases() {
                     let ip = tokens[2];
                     let hostname = tokens[3];
                     
-                    let entry = getMacEntry(mac);
-                    if (entry) {
-                        if (index(entry.ipv4, ip) == -1) {
-                            push(entry.ipv4, ip);
-                        }
+                    // Only merge lease info into entries already learned from
+                    // ARP/FDB - creating entries from leases alone fabricates
+                    // topology for clients that may be long gone, and a stale
+                    // lease (e.g. SSID moved to another network) must not be
+                    // appended next to the authoritative ARP-learned address.
+                    let nmac = normalizeMacAddress(mac);
+                    let entry = nmac ? macEntries[nmac] : null;
+                    if (entry && length(entry.ipv4) == 0) {
+                        push(entry.ipv4, ip);
                         // Could add hostname info if needed
                     }
                 }

--- a/system/state/wifi.uc
+++ b/system/state/wifi.uc
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as halow_module from './halow.uc';
 import * as telemetry_module from './telemetry.uc';
 import * as fingerprint_module from './fingerprint.uc';
+import * as network_module from './network.uc';
 
 /* Load WiFi data via require */
 let wifiphy = require('wifi.phy');
@@ -185,8 +186,17 @@ export function collect_wifi_ssids(iface) {
 				let fp = fingerprint_module.get_fingerprint_for_mac(assoc.station, null);
 				if (fp)
 					assoc.fingerprint = fp;
-				if (length(global.ip4leases[assoc.station]))
-					assoc.ipaddr_v4 = global.ip4leases[assoc.station];
+				let lease = global.ip4leases[assoc.station];
+
+				/* stations on a dynamic vlan lease from the vlan
+				 * network, which cannot be matched against this
+				 * iface - keep their lease as-is */
+				if (length(lease) && !assoc.dynamic_vlan &&
+				    !network_module.lease_matches_iface(lease, iface))
+					lease = null;
+
+				if (length(lease))
+					assoc.ipaddr_v4 = lease;
 				else if (global.snoop && global.snoop[assoc.station]) {
 					assoc.ipaddr_v4 = global.snoop[assoc.station];
 					if (!(assoc.station in global.macs)) {


### PR DESCRIPTION
…twork

The association ipaddr_v4 is looked up from /tmp/dhcp.leases by MAC only and takes precedence over dhcpsnoop. When an SSID is moved to a different network (e.g. downstream to upstream), the client's old lease remains until it expires, so the previous address keeps being reported even though dhcpsnoop already has the correct one.
Add lease_matches_iface() to only trust a lease whose address falls inside one of the interface's own IPv4 subnets, and fall back to the snooped address otherwise. Stations on dynamic VLANs keep their lease as-is since it belongs to the VLAN network, not the parent interface. Also apply the same check to the per-interface ipv4.leases list. In topology-mac, merge lease addresses only into MAC entries already learned from ARP/FDB, and only when no address was learned yet. Creating entries from leases alone fabricates topology for clients that may be long gone, and a stale lease would otherwise be appended next to the authoritative ARP-learned address. Subnet matching is not usable here because entry interfaces hold netdev names (bridge member ports), not netifd interfaces.

This fix is copied and adjusted from https://github.com/Telecominfraproject/wlan-ucentral-schema/pull/126#discussion_r3701362266

Fixes: WIFI-15635