### PR TITLE
health: skip SSIDs of disabled radios in the interface-level check

### DIFF
--- a/system/health.uc
+++ b/system/health.uc
@@ -196,6 +196,29 @@ function get_radio_match_info(section) {
 	return info;
 }
 
+// Helper function: can this wifi-iface be expected to be on the air?
+//
+// An SSID cannot come up when the iface itself is disabled, or when its parent
+// radio is disabled or absent from the config (e.g. a radio the operator turned
+// off via 'radios[].enable: false', which the renderer emits as
+// wireless.<phy>.disabled='1' while still rendering the SSID sections).
+// Counting those SSIDs as failures is a false positive, so both the
+// interface-level and the radio-level checks skip them.
+function iface_section_enabled(iface_section, wifi_config) {
+	if (iface_section.disabled == '1')
+		return false;
+
+	let dev_name = iface_section.device;
+	if (!dev_name)
+		return true;
+
+	let dev = wifi_config[dev_name];
+	if (!dev || dev['.type'] != 'wifi-device')
+		return false;
+
+	return dev.disabled != '1';
+}
+
 // Health check: per-radio SSID presence
 function check_radio_health(wifi_config, wifi_state) {
 	let radio_issues = {};
@@ -219,7 +242,7 @@ function check_radio_health(wifi_config, wifi_state) {
 			if (iface_section.device != dev_name)
 				continue;
 			/* Skip disabled, non-AP, or ssid-less ifaces */
-			if (iface_section.disabled == '1')
+			if (!iface_section_enabled(iface_section, wifi_config))
 				continue;
 			if (iface_section.mode && iface_section.mode != 'ap')
 				continue;
@@ -358,6 +381,10 @@ for (let iface in interfaces) {
 	for (let k, iface in wifi_config) {
 		if (iface['.type'] != 'wifi-iface' || iface.network != name)
 			continue;
+		/* SSIDs of a disabled iface or of a disabled/absent radio are not
+		 * expected on the air, so they must not count as interface errors. */
+		if (!iface_section_enabled(iface, wifi_config))
+			continue;
 		if (find_ssid(iface.ssid))
 			ssid[iface.ssid] = false;
 		if (iface.auth_server && iface.auth_port && iface.auth_secret && iface.health_username && iface.health_password && !iface.radius_gw_proxy)
@@ -441,7 +468,7 @@ let total_checks = count + radios_checked;
 let total_errors = iface_errors + radio_errors;
 let sanity = 100 - (total_errors * 100 / (total_checks || 1));
 
-warn(printf('health check reports sanity of %d (iface_errors=%d, radio_errors=%d)', sanity, iface_errors, radio_errors));
+warn(sprintf('health check reports sanity of %d (iface_errors=%d, radio_errors=%d)\n', sanity, iface_errors, radio_errors));
 ctx.call('ucentral', 'health', {sanity: sanity, data: state});
 let f = fs.open("/tmp/ucentral.health", "w");
 if (f) {


### PR DESCRIPTION
Issue: Turning a radio off (`radios[].enable: false`) still lowered the sanity score. The renderer sets wireless.`<phy>.disabled='1'` but keeps rendering that radio's wifi-iface sections, and only `check_radio_health()` honoured the flag, so an EAP101 with the 5G radio disabled reported sanity 50 (iface_errors=2, radio_errors=0)

Fix:
- Add `iface_section_enabled()`, used by both the interface-level loop and `check_radio_health()`, skipping a `wifi-iface` when it is disabled or its parent `wifi-device` is disabled or absent
- Also use `warn(sprintf(...))` for the summary log; `warn(printf(...))` sent the message to `stdout` and the byte count to `stderr`

Fixes: WIFI-15607