### PR TITLE
renderer: fix ethernet port handling on swconfig platforms

### DIFF
--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -388,7 +388,7 @@ let ethernet = {
 		for (let k, v in lookup) {
 			/* tagged swconfig downstream ports are not allowed */
 			if (interface.role == 'downstream') {
-				if (this.swconfig && this.swconfig[k].switch && v == 'tagged')
+				if (this.swconfig && this.swconfig[k]?.switch && v == 'tagged')
 					warn('%s:%d - vlan tagging on downstream swconfig ports is not supported', this.swconfig[k]?.switch.name, this.swconfig[k].swconfig);
 				else
 					rv[k] = v;

--- a/renderer/templates/toplevel.uc
+++ b/renderer/templates/toplevel.uc
@@ -81,23 +81,32 @@
 				continue;
 			ethernet.swconfig[port.netdev] = port;
 		}
-	} else {
-		// reject config if a wired port is used twice in un-tagged mode
-		let untagged_ports = [];
-		for (let i, interface in state.interfaces) {
-			if (interface.role != 'upstream')
+	}
+
+	/* map netdev names back to logical port names, for diagnostics */
+	let port_names = {};
+	for (let name, port in ethernet.ports)
+		port_names[port.netdev] = name;
+
+	/* reject config if a wired port is used twice in un-tagged mode. this has to run
+	 * after the swconfig port netdevs above have been resolved, as the port lookup
+	 * depends on them.
+	 */
+	let untagged_ports = [];
+	for (let i, interface in state.interfaces) {
+		if (interface.role != 'upstream')
+			continue;
+		let eth_ports = ethernet.lookup_by_interface_vlan(interface);
+		for (let port in keys(eth_ports)) {
+			if (ethernet.port_vlan(interface, eth_ports[port]))
 				continue;
-			let eth_ports = ethernet.lookup_by_interface_vlan(interface);
-			for (let port in keys(eth_ports)) {
-				if (ethernet.port_vlan(interface, eth_ports[port]))
-					continue;
-				if (port in untagged_ports) {
-					state.strict = true;
-					error('duplicate usage of un-tagged ports: ' + port);
-					return;
-				}
-				push(untagged_ports, port);
+			if (port in untagged_ports) {
+				state.strict = true;
+				error('duplicate usage of un-tagged ports: ' +
+				      (port_names[port] ? port_names[port] + ' (' + port + ')' : port));
+				return;
 			}
+			push(untagged_ports, port);
 		}
 	}
 


### PR DESCRIPTION
## Problem

On platforms with a swconfig-managed internal switch (EAP104 and any board exposing
`capab.switch`), a config that gives two upstream interfaces the same un-tagged port is
accepted and applied, taking the AP's uplink down with no error reported to the
controller. Both interfaces get their own dynamic internal VID and both claim `eth0`
un-tagged in bridge `up`. The kernel keeps a single PVID per port, so the last one
applied wins and un-tagged WAN traffic lands in the wrong logical interface, leaving the
DHCP upstream without a lease or route.

Separately, a downstream interface that selects a port not behind the internal switch
(`select-ports` `"*"` or `"WAN*"` on EAP104, where `eth0` is on the internal IPQ5018
switch) aborts the whole render, as ucode raises a reference error on member access
through null.

Found while investigating a customer escalation on EAP104.

## Root Cause

`toplevel.uc` has a hard rejection for duplicate un-tagged ports, but it sits in the
`else` branch of `if (swconfig)`, making it mutually exclusive with the platforms above.
It cannot simply be hoisted, since `ethernet.lookup_by_interface_vlan()` consults
`ethernet.swconfig`, which is populated inside the `if`.

`lookup_by_interface_vlan()` dereferences `this.swconfig[k].switch` without a null guard
in its downstream branch, two lines above an upstream branch that guards the same access
with `?.`. `ethernet.swconfig` holds only ports behind the switch, while the port lookup
returns every matched port.

## Solution

- Move the duplicate un-tagged port check out of the `else` so it runs on all platforms,
  positioned after swconfig netdev resolution. Map netdev names back to logical port
  names so the error names a port an operator recognises, `WAN (eth0)` rather than a bare
  internal netdev.
- Add the missing optional chaining in the downstream branch, so non-switch ports fall
  through and are added like any other port.

Fixes: WIFI-15648