### PR TITLE
captive: fix portal redirection and captive client state reporting

### DIFF
--- a/renderer/renderer.uc
+++ b/renderer/renderer.uc
@@ -1073,7 +1073,23 @@ let routing_table = {
 let captive = {
 	interfaces: {},
 
+	netdev: {},
+
 	next: 0,
+
+	/**
+	 * Record the kernel netdev backing a captive capable interface.
+	 *
+	 * netifd names an auto created bridge br-<network>, while the bridge-vlan
+	 * path yields an explicit 8021q device named <network>. spotfilter resolves
+	 * class device_macaddr via SIOCGIFHWADDR, so it needs the real netdev name.
+	 *
+	 * @param {string} name  The logical interface name, e.g. down2v0
+	 * @param {string} dev   The kernel netdev name, e.g. br-down2v0
+	 */
+	set_netdev: function(name, dev) {
+		this.netdev[name] = dev;
+	},
 
 	/**
 	 * Allocate a route table index for the given ID

--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -150,6 +150,12 @@
 	if (tunnel_proto in [ "mesh", "l2tp", "vxlan", "gre", "gre6" ])
 		include("interface/" + tunnel_proto + ".uc", { interface, name, eth_ports, location, netdev, ipv4_mode, ipv6_mode, this_vid });
 
+	// Track the kernel netdev backing this interface so the spotfilter template
+	// can resolve a MAC from it. Only record it where the name is unambiguous:
+	// naming a netdev that does not exist is worse than omitting the field,
+	// because spotfilter zeroes the whole traffic class when the lookup fails.
+	let captive_netdev;
+
 	if (!interface.ethernet && length(interface.ssids) == 1 && !tunnel_proto && !("vxlan-overlay" in interface.services)) {
 		if (interface.role == 'downstream')
 			interface.type = 'bridge';
@@ -157,9 +163,19 @@
 	} else if (tunnel_proto == 'vxlan') {
 		netdev = '@' + name + '_vx';
 		interface.type = 'bridge';
-	} else if (tunnel_proto != 'gre' && tunnel_proto != 'gre6')
+	} else if (tunnel_proto != 'gre' && tunnel_proto != 'gre6') {
 		// anything else requires a bridge-vlan
 		include("interface/bridge-vlan.uc", { interface, name, eth_ports, this_vid, bridgedev, swconfig });
+		// bridge-vlan.uc emits an explicit 8021q device named after the interface
+		captive_netdev = name;
+	}
+
+	// netifd auto names a type=bridge interface br-<network>
+	if (interface.type == 'bridge')
+		captive_netdev = 'br-' + name;
+
+	if (captive_netdev)
+		captive.set_netdev(name, captive_netdev);
 
 	if (interface.role == "downstream" && "wireguard-overlay" in interface.services)
 		dest = 'unet';

--- a/renderer/templates/spotfilter.uc
+++ b/renderer/templates/spotfilter.uc
@@ -5,6 +5,19 @@ if (enable != 1)
 	return;
 
 for (let name, data in captive.interfaces) {
+	/* spotfilter resolves device_macaddr with SIOCGIFHWADDR, so it has to be a
+	 * kernel netdev name. Use the name interface.uc recorded rather than
+	 * deriving it, since a type=bridge interface is br-<network> while the
+	 * bridge-vlan path is an 8021q device named <network>. */
+	let class0 = {
+		index: 0,
+		fwmark: 1,
+		fwmark_mask: 127
+	};
+	let netdev = captive.netdev[split(name, '_')[0]];
+	if (netdev)
+		class0.device_macaddr = netdev;
+
 	let config = {
 		name,
 		devices: [],
@@ -13,12 +26,8 @@ for (let name, data in captive.interfaces) {
 			default_dns_class: 1,
 			client_autoremove: false,
 			class: [
+				class0,
 				{
-					index: 0,
-					device_macaddr: split(name, '_')[0],
-					fwmark: 1,
-					fwmark_mask: 127
-				}, {
 					index: 1,
 					fwmark: 2,
 					fwmark_mask: 127

--- a/system/state.uc
+++ b/system/state.uc
@@ -173,7 +173,25 @@ if (fingerprint) {
 let lldp = [];
 let wireless = cursor.get_all("wireless");
 let snoop = ctx.call("dhcpsnoop", "dump");
-let captive = ctx.call("spotfilter", "client_list", { "interface": "hotspot"});
+
+/* spotfilter interfaces are named after the uspot config sections that the
+ * renderer emits (e.g. "down2v0_0"), so query each one instead of assuming a
+ * fixed "hotspot" instance. */
+function captive_clients() {
+	let res = {};
+
+	for (let section, config in cursor.get_all("uspot") ?? {}) {
+		if (config?.[".type"] != "uspot")
+			continue;
+		let clients = ctx.call("spotfilter", "client_list", { interface: section });
+		for (let mac, val in clients)
+			res[mac] = val;
+	}
+
+	return res;
+}
+
+let captive = captive_clients();
 
 function generate_deltas(counters, prev_counters) {
 	let ret = {};


### PR DESCRIPTION
Two defects in the captive portal path.

1) Redirection never worked. Unauthenticated clients reached the upstream directly instead of being DNAT'd to the local portal, and the nft counters on every "mark 1/127" rule in forward_<iface> stayed at zero, so no packet was ever classified as pre-auth.

Class 0 device_macaddr was rendered as split(name, '_')[0], giving the logical interface name (down2v0_0 -> down2v0). spotfilter resolves that field as a kernel netdev through SIOCGIFHWADDR in
interface_parse_class(). An interface rendered as type=bridge is auto named br-down2v0 by netifd and no netdev called down2v0 exists, so the lookup fails. spotfilter then takes its "invalid" path, which zeroes cdata->actions and so drops SPOTFILTER_ACTION_FWMARK, but still returns the class index, installing a zeroed class 0 into BPF. Class 0 carries fwmark 1, so pre-auth clients were never marked and the DNAT redirect, walled-garden allow and pre-captive drop rules could not match.

The name cannot be derived from the interface name alone, because captive is restricted to neither bridged nor downstream interfaces: an SSID enables it via ssid.services, which neither the interface.captive guard nor lookup_interfaces_by_ssids() constrains by role. Record the netdev where interface.uc already decides it, br-<network> for type=bridge and the explicit 8021q device named <network> on the bridge-vlan path. Where no predictable netdev exists, such as gre tunnels or an unbridged interface, omit the field so spotfilter skips the lookup rather than zeroing the class. That only forgoes the dest-MAC rewrite used to capture NAT mode traffic, far less harmful than losing classification entirely.

2) Captive clients never reached the state message, so the cloud could not see who was in the walled garden or authenticated. client_list was called with a hardcoded interface name of "hotspot", while the renderer names the spotfilter interface after the uspot section it emits (down2v0_0), so the lookup never matched. Iterate the uspot sections and merge each client list, filtering on section type to skip the anonymous "credentials" sections. Output stays keyed by client MAC, so state.captive is unchanged and an absent uspot package still yields an empty object.

normalize_device_macaddr() on main carries the same expression and needs the same fix.

Fixes: WIFI-15647