### PR TITLE
captive: fix portal redirection and captive client state reporting

### DIFF
--- a/renderer/libs/captive.uc
+++ b/renderer/libs/captive.uc
@@ -15,7 +15,23 @@ export function create_captive() {
 	return {
 		interfaces: {},
 
+		netdev: {},
+
 		next: 0,
+
+		/**
+		 * Record the kernel netdev backing a captive capable interface.
+		 *
+		 * netifd names an auto created bridge br-<network>, while the bridge-vlan
+		 * path yields an explicit 8021q device named <network>. spotfilter resolves
+		 * class device_macaddr via SIOCGIFHWADDR, so it needs the real netdev name.
+		 *
+		 * @param {string} name  The logical interface name, e.g. down2v0
+		 * @param {string} dev   The kernel netdev name, e.g. br-down2v0
+		 */
+		set_netdev: function(name, dev) {
+			this.netdev[name] = dev;
+		},
 
 		/**
 		 * Allocate a route table index for the given ID

--- a/renderer/templates/interface.uc
+++ b/renderer/templates/interface.uc
@@ -304,6 +304,12 @@
 	if (tunnel_proto in [ "mesh", "l2tp", "vxlan", "gre", "gre6" ])
 		include("interface/" + tunnel_proto + ".uc", { interface, name, eth_ports, location, netdev, ipv4_mode, ipv6_mode, this_vid });
 
+	// Track the kernel netdev backing this interface so the spotfilter template
+	// can resolve a MAC from it. Only record it where the name is unambiguous:
+	// naming a netdev that does not exist is worse than omitting the field,
+	// because spotfilter zeroes the whole traffic class when the lookup fails.
+	let captive_netdev;
+
 	if (!interface.ethernet && length(interface.ssids) == 1 && !tunnel_proto && !("vxlan-overlay" in interface.services)) {
 		if (interface.role == 'downstream')
 			interface.type = 'bridge';
@@ -311,9 +317,19 @@
 	} else if (tunnel_proto == 'vxlan') {
 		netdev = '@' + name + '_vx';
 		interface.type = 'bridge';
-	} else if (tunnel_proto != 'gre' && tunnel_proto != 'gre6')
+	} else if (tunnel_proto != 'gre' && tunnel_proto != 'gre6') {
 		// anything else requires a bridge-vlan
 		include("interface/bridge-vlan.uc", { interface, name, eth_ports, this_vid, bridgedev, swconfig });
+		// bridge-vlan.uc emits an explicit 8021q device named after the interface
+		captive_netdev = name;
+	}
+
+	// netifd auto names a type=bridge interface br-<network>
+	if (interface.type == 'bridge')
+		captive_netdev = 'br-' + name;
+
+	if (captive_netdev)
+		captive.set_netdev(name, captive_netdev);
 
 	include("interface/common.uc", {
 		name, this_vid, netdev,

--- a/renderer/templates/spotfilter.uc
+++ b/renderer/templates/spotfilter.uc
@@ -42,8 +42,29 @@
 	}
 
 	// normalize_ functions - data transformation
+
+	/* spotfilter resolves device_macaddr with SIOCGIFHWADDR, so it has to be a
+	 * kernel netdev name. Use the name interface.uc recorded rather than
+	 * deriving it, since a type=bridge interface is br-<network> while the
+	 * bridge-vlan path is an 8021q device named <network>. Returns null when no
+	 * predictable netdev exists, so the field is omitted rather than pointing at
+	 * a device that does not exist, which would make spotfilter zero the class. */
 	function normalize_device_macaddr(name) {
-		return split(name, '_')[0];
+		return captive.netdev[split(name, '_')[0]];
+	}
+
+	function normalize_class0(name) {
+		let class0 = {
+			index: SPOTFILTER_CLASSES[0].index,
+			fwmark: SPOTFILTER_CLASSES[0].fwmark,
+			fwmark_mask: SPOTFILTER_CLASSES[0].fwmark_mask
+		};
+
+		let netdev = normalize_device_macaddr(name);
+		if (netdev)
+			class0.device_macaddr = netdev;
+
+		return class0;
 	}
 
 	function normalize_interface_devices(data) {
@@ -77,12 +98,7 @@
 				default_dns_class: SPOTFILTER_DEFAULTS.default_dns_class,
 				client_autoremove: SPOTFILTER_DEFAULTS.client_autoremove,
 				class: [
-					{
-						index: SPOTFILTER_CLASSES[0].index,
-						device_macaddr: normalize_device_macaddr(name),
-						fwmark: SPOTFILTER_CLASSES[0].fwmark,
-						fwmark_mask: SPOTFILTER_CLASSES[0].fwmark_mask
-					},
+					normalize_class0(name),
 					{
 						index: SPOTFILTER_CLASSES[1].index,
 						fwmark: SPOTFILTER_CLASSES[1].fwmark,

--- a/system/state/captive.uc
+++ b/system/state/captive.uc
@@ -1,7 +1,24 @@
+/* spotfilter interfaces are named after the uspot config sections that the
+ * renderer emits (e.g. "down2v0_0"), so query each one instead of assuming a
+ * fixed "hotspot" instance. */
+function captive_clients() {
+	let res = {};
+
+	for (let section, config in global.uci.get_all("uspot") ?? {}) {
+		if (config?.[".type"] != "uspot")
+			continue;
+		let clients = global.ubus.call("spotfilter", "client_list", { interface: section });
+		for (let mac, val in clients)
+			res[mac] = val;
+	}
+
+	return res;
+}
+
 export function collect(state) {
 	/* Collect data via ubus */
-	let captive = global.ubus.call("spotfilter", "client_list", { "interface": "hotspot"});
-	
+	let captive = captive_clients();
+
 	if (!length(captive))
 		return;
 		


### PR DESCRIPTION
Two defects in the captive portal path.

1) Redirection never worked. Unauthenticated clients reached the upstream directly instead of being DNAT'd to the local portal, and the nft counters on every "mark 1/127" rule in forward_<iface> stayed at zero, so no packet was ever classified as pre-auth.

Class 0 device_macaddr was rendered as split(name, '_')[0], giving the logical interface name (down2v0_0 -> down2v0). spotfilter resolves that field as a kernel netdev through SIOCGIFHWADDR in
interface_parse_class(). An interface rendered as type=bridge is auto named br-down2v0 by netifd and no netdev called down2v0 exists, so the lookup fails. spotfilter then takes its "invalid" path, which zeroes cdata->actions and so drops SPOTFILTER_ACTION_FWMARK, but still returns the class index, installing a zeroed class 0 into BPF. Class 0 carries fwmark 1, so pre-auth clients were never marked and the DNAT redirect, walled-garden allow and pre-captive drop rules could not match.

The name cannot be derived from the interface name alone, because captive is restricted to neither bridged nor downstream interfaces: an SSID enables it via ssid.services, which neither the interface.captive guard nor lookup_interfaces_by_ssids() constrains by role. Record the netdev where interface.uc already decides it, br-<network> for type=bridge and the explicit 8021q device named <network> on the bridge-vlan path. Where no predictable netdev exists, such as gre tunnels or an unbridged interface, omit the field so spotfilter skips the lookup rather than zeroing the class. That only forgoes the dest-MAC rewrite used to capture NAT mode traffic, far less harmful than losing classification entirely.

2) Captive clients never reached the state message, so the cloud could not see who was in the walled garden or authenticated. client_list was called with a hardcoded interface name of "hotspot", while the renderer names the spotfilter interface after the uspot section it emits (down2v0_0), so the lookup never matched. Iterate the uspot sections and merge each client list, filtering on section type to skip the anonymous "credentials" sections. Output stays keyed by client MAC, so state.captive is unchanged and an absent uspot package still yields an empty object.

The netdev map and set_netdev() live in libs/captive.uc, which now owns the captive object. normalize_device_macaddr() resolves through that map and class 0 is built by normalize_class0() so device_macaddr can be omitted. The client_list call sits in state/captive.uc, which already reshapes the client data.

Fixes: WIFI-15647